### PR TITLE
Removes inconsistent "Type" suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ defmodule MyApp.Schema do
   }
 
   def query do
-    %Type.ObjectType{
+    %Type.Object{
       fields: fields(
         item: [
           type: :item
@@ -136,7 +136,7 @@ We haven't defined that yet; let's do it. In the same `MyApp.Schema` module:
 ```elixir
 @absinthe :type
 def item do
-  %Type.ObjectType{
+  %Type.Object{
     description: "An item",
     fields: fields(
       id: [type: :id],
@@ -150,7 +150,7 @@ Some notes on defining types:
 
 * By default, they will have the same atom identifier (eg, `:item`) as the
   defining function. This can be overridden, eg, `@absinthe type: :my_custom_name`
-* The `name` field of the `Type.ObjectType` struct is optional; if not provided,
+* The `name` field of the `Type.Object` struct is optional; if not provided,
   it will be automatically set to a TitleCase version of the type identifier
   (in this case, it's set to `"Item"`).
 * You can define additional scalar types (including coercion logic); see
@@ -205,7 +205,7 @@ passing an optional `reason`:
 
 ```elixir
 def query do
-  %Type.ObjectType{
+  %Type.Object{
     name: "RootQuery",
     fields: fields(
       item: [

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -51,7 +51,7 @@ defmodule Absinthe do
     }
 
     def query do
-      %Absinthe.Type.ObjectType{
+      %Absinthe.Type.Object{
         fields: fields(
           item: [
             type: :item,
@@ -69,7 +69,7 @@ defmodule Absinthe do
 
     @absinthe :type
     def item do
-      %Absinthe.Type.ObjectType{
+      %Absinthe.Type.Object{
         description: "A valuable item",
         fields: fields(
           id: [type: :id],

--- a/lib/absinthe/execution.ex
+++ b/lib/absinthe/execution.ex
@@ -20,7 +20,7 @@ defmodule Absinthe.Execution do
   @typedoc "The canonical result representation of an execution"
   @type result_t :: %{data: %{binary => any}, errors: [error_t]} | %{data: %{binary => any}} | %{errors: [error_t]}
 
-  @type t :: %{schema: Schema.t, document: Language.Document.t, variables: map, selected_operation: Absinthe.Type.ObjectType.t, operation_name: binary, errors: [error_t], categorized: boolean, strategy: atom, adapter: atom, resolution: Execution.Resolution.t}
+  @type t :: %{schema: Schema.t, document: Language.Document.t, variables: map, selected_operation: Absinthe.Type.Object.t, operation_name: binary, errors: [error_t], categorized: boolean, strategy: atom, adapter: atom, resolution: Execution.Resolution.t}
   defstruct schema: nil, document: nil, variables: %{}, fragments: %{}, operations: %{}, selected_operation: nil, operation_name: nil, errors: [], categorized: false, strategy: nil, adapter: nil, resolution: nil
 
   @doc false
@@ -112,9 +112,9 @@ defmodule Absinthe.Execution do
   def resolve_type(_target, %Type.Union{} = child_type, parent_type) do
     child_type |> Type.Union.member?(parent_type) || nil
   end
-  def resolve_type(target, %Type.InterfaceType{} = _child_type, _parent_type) do
+  def resolve_type(target, %Type.Interface{} = _child_type, _parent_type) do
     target
-    |> Type.InterfaceType.resolve_type
+    |> Type.Interface.resolve_type
   end
   def resolve_type(_target, child_type, parent_type) when child_type == parent_type do
     parent_type
@@ -163,7 +163,7 @@ defmodule Absinthe.Execution do
   end
 
   @doc false
-  @spec selected_operation(t) :: {:ok, Absinthe.Type.ObjectType.t | nil} | {:error, binary}
+  @spec selected_operation(t) :: {:ok, Absinthe.Type.Object.t | nil} | {:error, binary}
   def selected_operation(%{categorized: false}) do
     {:error, "Call Execution.categorize_definitions first"}
   end

--- a/lib/absinthe/execution/arguments.ex
+++ b/lib/absinthe/execution/arguments.ex
@@ -132,7 +132,7 @@ defmodule Absinthe.Execution.Arguments do
     end
   end
   # Input object value found
-  defp do_add_argument_value(%Type.InputObjectType{fields: schema_fields}, %{fields: input_fields}, ast_argument, [value_name | _] = names, {values, {missing, invalid}, execution}) do
+  defp do_add_argument_value(%Type.InputObject{fields: schema_fields}, %{fields: input_fields}, ast_argument, [value_name | _] = names, {values, {missing, invalid}, execution}) do
     {_, object_values, {new_missing, new_invalid}, execution_to_return} = schema_fields
     |> Enum.reduce({names, %{}, {missing, invalid}, execution}, fn ({name, schema_field}, {acc_value_name, acc_values, {acc_missing, acc_invalid}, acc_execution}) ->
       input_field = input_fields |> Enum.find(&(&1.name == name |> to_string))

--- a/lib/absinthe/execution/resolution/object.ex
+++ b/lib/absinthe/execution/resolution/object.ex
@@ -1,4 +1,4 @@
-defimpl Absinthe.Execution.Resolution, for: Absinthe.Type.ObjectType do
+defimpl Absinthe.Execution.Resolution, for: Absinthe.Type.Object do
 
   alias Absinthe.Execution.Resolution
 

--- a/lib/absinthe/execution/resolution/selection_set.ex
+++ b/lib/absinthe/execution/resolution/selection_set.ex
@@ -76,7 +76,7 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.SelectionSet do
 
   @spec merge_fields(Language.t, Language.t, Execution.t) :: Language.t
   defp merge_fields(_field1, field2, %{schema: _schema}) do
-    # TODO: Merge fields into a new Language.Field.t if the field_type is ObjectType.t
+    # TODO: Merge fields into a new Language.Field.t if the field_type is Object.t
     # field_type = schema |> Schema.field(resolution.type, field2.name).type |> Type.unwrap
     field2
   end

--- a/lib/absinthe/language.ex
+++ b/lib/absinthe/language.ex
@@ -6,7 +6,7 @@ defmodule Absinthe.Language do
 
   @type t :: Language.Argument.t
   | Language.BooleanValue.t
-  | Language.Directive.t | Language.Document.t | Language.EnumTypeDefinition.t | Language.EnumValue.t | Language.Field.t | Language.FieldDefinition.t | Language.FloatValue.t | Language.FragmentDefinition.t | Language.FragmentSpread.t | Language.InlineFragment.t | Language.InputObjectTypeDefinition.t | Language.InputValueDefinition.t | Language.IntValue.t | Language.InterfaceTypeDefinition.t | Language.ListType.t | Language.ListValue.t | Language.NamedType.t | Language.NonNullType.t | Language.ObjectField.t | Language.ObjectTypeDefinition.t | Language.ObjectValue.t | Language.OperationDefinition.t | Language.ScalarTypeDefinition.t | Language.SelectionSet.t | Language.Source.t | Language.StringValue.t | Language.TypeExtensionDefinition.t | Language.UnionTypeDefinition.t | Language.Variable.t | Language.VariableDefinition.t
+  | Language.Directive.t | Language.Document.t | Language.EnumTypeDefinition.t | Language.EnumValue.t | Language.Field.t | Language.FieldDefinition.t | Language.FloatValue.t | Language.FragmentDefinition.t | Language.FragmentSpread.t | Language.InlineFragment.t | Language.InputObjectDefinition.t | Language.InputValueDefinition.t | Language.IntValue.t | Language.InterfaceDefinition.t | Language.ListType.t | Language.ListValue.t | Language.NamedType.t | Language.NonNullType.t | Language.ObjectField.t | Language.ObjectDefinition.t | Language.ObjectValue.t | Language.OperationDefinition.t | Language.ScalarTypeDefinition.t | Language.SelectionSet.t | Language.Source.t | Language.StringValue.t | Language.TypeExtensionDefinition.t | Language.UnionTypeDefinition.t | Language.Variable.t | Language.VariableDefinition.t
 
   # Value nodes
   @type value_t :: Language.Variable.t | Language.IntValue.t | Language.FloatValue.t | Language.StringValue.t | Language.BooleanValue.t | Language.EnumValue.t | Language.ListValue.t | Language.ObjectValue.t
@@ -15,7 +15,7 @@ defmodule Absinthe.Language do
   @type type_reference_t :: Language.NamedType.t | Language.ListType.t | Language.NonNullType.t
 
   # Type definition nodes
-  @type type_definition_t :: Language.ObjectTypeDefinition.t | Language.InterfaceTypeDefinition.t | Language.UnionTypeDefinition.t | Language.ScalarTypeDefinition.t | Language.EnumTypeDefinition.t | Language.InputObjectTypeDefinition.t | Language.TypeExtensionDefinition.t
+  @type type_definition_t :: Language.ObjectDefinition.t | Language.InterfaceDefinition.t | Language.UnionTypeDefinition.t | Language.ScalarTypeDefinition.t | Language.EnumTypeDefinition.t | Language.InputObjectDefinition.t | Language.TypeExtensionDefinition.t
 
   @type loc_t :: %{start_line: nil | integer,
                    end_line:   nil | integer}

--- a/lib/absinthe/language/input_object_definition.ex
+++ b/lib/absinthe/language/input_object_definition.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Language.InputObjectTypeDefinition do
+defmodule Absinthe.Language.InputObjectDefinition do
 
   @moduledoc false
 

--- a/lib/absinthe/language/interface_definition.ex
+++ b/lib/absinthe/language/interface_definition.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Language.InterfaceTypeDefinition do
+defmodule Absinthe.Language.InterfaceDefinition do
 
   @moduledoc false
 

--- a/lib/absinthe/language/object_definition.ex
+++ b/lib/absinthe/language/object_definition.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Language.ObjectTypeDefinition do
+defmodule Absinthe.Language.ObjectDefinition do
 
   @moduledoc false
 

--- a/lib/absinthe/schema.ex
+++ b/lib/absinthe/schema.ex
@@ -37,7 +37,7 @@ defmodule Absinthe.Schema do
   }
 
   def query do
-    %Absinthe.Type.ObjectType{
+    %Absinthe.Type.Object{
       fields: fields(
         item: [
           type: :item,
@@ -61,7 +61,7 @@ defmodule Absinthe.Schema do
   and arguments.
 
   For more information on object types (especially how the `resolve`
-  function works above), see `Absinthe.Type.ObjectType`.
+  function works above), see `Absinthe.Type.Object`.
 
   You may also notice we've declared that the resolved value of the field
   to be of `type: :item`. We now need to define exactly what an `:item` is,
@@ -74,7 +74,7 @@ defmodule Absinthe.Schema do
   ```
   @absinthe :type
   def item do
-    %Absinthe.Type.ObjectType{
+    %Absinthe.Type.Object{
       description: "A valuable item",
       fields: fields(
         id: [type: :id],
@@ -136,23 +136,23 @@ defmodule Absinthe.Schema do
   @doc """
   (Required) Define the query root type.
 
-  Should be an `Absinthe.Type.ObjectType` struct.
+  Should be an `Absinthe.Type.Object` struct.
   """
-  @callback query :: Absinthe.Type.ObjectType.t
+  @callback query :: Absinthe.Type.Object.t
 
   @doc """
   (Optional) Define the mutation root type.
 
-  Should be an `Absinthe.Type.ObjectType` struct.
+  Should be an `Absinthe.Type.Object` struct.
   """
-  @callback mutation :: nil | Absinthe.Type.ObjectType.t
+  @callback mutation :: nil | Absinthe.Type.Object.t
 
   @doc """
   (Optional) Define the subscription root type.
 
-  Should be an `Absinthe.Type.ObjectType` struct.
+  Should be an `Absinthe.Type.Object` struct.
   """
-  @callback subscription :: nil | Absinthe.Type.ObjectType.t
+  @callback subscription :: nil | Absinthe.Type.Object.t
 
   alias Absinthe.Type
   alias Absinthe.Language
@@ -165,9 +165,9 @@ defmodule Absinthe.Schema do
   the necessary `Absinthe.Schema` callbacks and
   use `schema/0`
   """
-  @type t :: %{query: Absinthe.Type.ObjectType.t,
-               mutation: nil | Absinthe.Type.ObjectType.t,
-               subscription: nil | Absinthe.Type.ObjectType.t,
+  @type t :: %{query: Absinthe.Type.Object.t,
+               mutation: nil | Absinthe.Type.Object.t,
+               subscription: nil | Absinthe.Type.Object.t,
                type_modules: [atom],
                types: Schema.Types.typemap_t,
                errors: [binary]}

--- a/lib/absinthe/type.ex
+++ b/lib/absinthe/type.ex
@@ -6,10 +6,10 @@ defmodule Absinthe.Type do
 
   # ALL TYPES
 
-  @type_modules [Type.Scalar, Type.ObjectType, Type.InterfaceType, Type.Union, Type.Enum, Type.InputObjectType, Type.List, Type.NonNull]
+  @type_modules [Type.Scalar, Type.Object, Type.Interface, Type.Union, Type.Enum, Type.InputObject, Type.List, Type.NonNull]
 
   @typedoc "These are all of the possible kinds of types."
-  @type t :: Type.Scalar.t | Type.ObjectType.t | Type.FieldDefinition.t | Type.InterfaceType.t | Type.Union.t | Type.Enum.t | Type.InputObjectType.t | Type.List.t | Type.NonNull.t
+  @type t :: Type.Scalar.t | Type.Object.t | Type.FieldDefinition.t | Type.Interface.t | Type.Union.t | Type.Enum.t | Type.InputObject.t | Type.List.t | Type.NonNull.t
 
   @typedoc "A type identifier"
   @type identifier_t :: atom
@@ -21,10 +21,10 @@ defmodule Absinthe.Type do
 
   # INPUT TYPES
 
-  @input_type_modules [Type.Scalar, Type.Enum, Type.InputObjectType, Type.List, Type.NonNull]
+  @input_type_modules [Type.Scalar, Type.Enum, Type.InputObject, Type.List, Type.NonNull]
 
   @typedoc "These types may be used as input types for arguments and directives."
-  @type input_t :: Type.Scalar.t | Type.Enum.t | Type.InputObjectType.t | Type.List.t | Type.NonNull.t
+  @type input_t :: Type.Scalar.t | Type.Enum.t | Type.InputObject.t | Type.List.t | Type.NonNull.t
 
   @doc "Determine if a term is an input type"
   @spec input_type?(any) :: boolean
@@ -41,7 +41,7 @@ defmodule Absinthe.Type do
 
   @doc "Determine if a term is an object type"
   @spec object_type?(any) :: boolean
-  def object_type?(%Type.ObjectType{}), do: true
+  def object_type?(%Type.Object{}), do: true
   def object_type?(_), do: false
 
   @doc "Resolve a type for a value from an interface (if necessary)"
@@ -58,10 +58,10 @@ defmodule Absinthe.Type do
 
   # OUTPUT TYPES
 
-  @output_type_modules [Type.Scalar, Type.ObjectType, Type.InterfaceType, Type.Union, Type.Enum]
+  @output_type_modules [Type.Scalar, Type.Object, Type.Interface, Type.Union, Type.Enum]
 
   @typedoc "These types may be used as output types as the result of fields."
-  @type output_t :: Type.Scalar.t | Type.ObjectType.t | Type.InterfaceType.t | Type.Union.t | Type.Enum.t
+  @type output_t :: Type.Scalar.t | Type.Object.t | Type.Interface.t | Type.Union.t | Type.Enum.t
 
   @doc "Determine if a term is an output type"
   @spec output_type?(any) :: boolean
@@ -94,10 +94,10 @@ defmodule Absinthe.Type do
 
   # COMPOSITE TYPES
 
-  @composite_type_modules [Type.ObjectType, Type.InterfaceType, Type.Union]
+  @composite_type_modules [Type.Object, Type.Interface, Type.Union]
 
   @typedoc "These types may describe the parent context of a selection set."
-  @type composite_t :: Type.ObjectType.t | Type.InterfaceType.t | Type.Union.t
+  @type composite_t :: Type.Object.t | Type.Interface.t | Type.Union.t
 
   @doc "Determine if a term is a composite type"
   @spec composite_type?(any) :: boolean
@@ -106,10 +106,10 @@ defmodule Absinthe.Type do
 
   # ABSTRACT TYPES
 
-  @abstract_type_modules [Type.InterfaceType, Type.Union]
+  @abstract_type_modules [Type.Interface, Type.Union]
 
   @typedoc "These types may describe the parent context of a selection set."
-  @type abstract_t :: Type.InterfaceType.t | Type.Union.t
+  @type abstract_t :: Type.Interface.t | Type.Union.t
 
   @doc "Determine if a term is an abstract type"
   @spec abstract?(any) :: boolean
@@ -118,10 +118,10 @@ defmodule Absinthe.Type do
 
   # NULLABLE TYPES
 
-  @nullable_type_modules [Type.Scalar, Type.ObjectType, Type.InterfaceType, Type.Union, Type.Enum, Type.InputObjectType, Type.List]
+  @nullable_type_modules [Type.Scalar, Type.Object, Type.Interface, Type.Union, Type.Enum, Type.InputObject, Type.List]
 
   @typedoc "These types can all accept null as a value."
-  @type nullable_t :: Type.Scalar.t | Type.ObjectType.t | Type.InterfaceType.t | Type.Union.t | Type.Enum.t | Type.InputObjectType.t | Type.List.t
+  @type nullable_t :: Type.Scalar.t | Type.Object.t | Type.Interface.t | Type.Union.t | Type.Enum.t | Type.InputObject.t | Type.List.t
 
   @doc "Unwrap the underlying nullable type or return unmodified"
   @spec nullable(any) :: nullable_t | t # nullable_t is a subset of t, but broken out for clarity
@@ -135,10 +135,10 @@ defmodule Absinthe.Type do
 
   # NAMED TYPES
 
-  @named_type_modules [Type.Scalar, Type.ObjectType, Type.InterfaceType, Type.Union, Type.Enum, Type.InputObjectType]
+  @named_type_modules [Type.Scalar, Type.Object, Type.Interface, Type.Union, Type.Enum, Type.InputObject]
 
   @typedoc "These named types do not include modifiers like Absinthe.Type.List or Absinthe.Type.NonNull."
-  @type named_t :: Type.Scalar.t | Type.ObjectType.t | Type.InterfaceType.t | Type.Union.t | Type.Enum.t | Type.InputObjectType.t
+  @type named_t :: Type.Scalar.t | Type.Object.t | Type.Interface.t | Type.Union.t | Type.Enum.t | Type.InputObject.t
 
   @doc "Determine the underlying named type, if any"
   @spec named_type(any) :: nil | named_t

--- a/lib/absinthe/type/definitions.ex
+++ b/lib/absinthe/type/definitions.ex
@@ -60,7 +60,7 @@ defmodule Absinthe.Type.Definitions do
   ## Examples
 
   Wrap around an argument or a field definition
-  (of a `Absinthe.Type.InputObjectType`) to deprecate it:
+  (of a `Absinthe.Type.InputObject`) to deprecate it:
 
   ```
   args(

--- a/lib/absinthe/type/field_definition.ex
+++ b/lib/absinthe/type/field_definition.ex
@@ -39,11 +39,11 @@ defmodule Absinthe.Type.FieldDefinition do
       {:ok, Map.get(parent_object, field_name)}
 
   This is commonly use when listing the available fields on a
-  `Absinthe.Type.ObjectType` that models a data record. For instance:
+  `Absinthe.Type.Object` that models a data record. For instance:
 
       @absinthe :type
       def person do
-        %Absinthe.Type.ObjectType{
+        %Absinthe.Type.Object{
           description: "A Person"
           fields: fields(
             first_name: [type: :string],
@@ -59,7 +59,7 @@ defmodule Absinthe.Type.FieldDefinition do
   users for a given `location_id`:
 
       def query do
-        %Absinthe.Type.ObjectType{
+        %Absinthe.Type.Object{
           fields: fields(
             users: [
               type: :person,

--- a/lib/absinthe/type/input_object.ex
+++ b/lib/absinthe/type/input_object.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Type.InputObjectType do
+defmodule Absinthe.Type.InputObject do
 
   alias Absinthe.Type
 

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -1,11 +1,11 @@
-defmodule Absinthe.Type.InterfaceType do
+defmodule Absinthe.Type.Interface do
 
   # TODO: Interfaces are not yet fully supported
   @moduledoc false
 
   alias Absinthe.Type
 
-  @type t :: %{name: binary, description: binary, fields: map, resolve_type: ((any, Absinthe.Type.ResolveInfo.t) -> Absinthe.Type.ObjectType.t), types: [Absinthe.Type.t], reference: Type.Reference.t}
+  @type t :: %{name: binary, description: binary, fields: map, resolve_type: ((any, Absinthe.Type.ResolveInfo.t) -> Absinthe.Type.Object.t), types: [Absinthe.Type.t], reference: Type.Reference.t}
   defstruct name: nil, description: nil, fields: nil, resolve_type: nil, types: [], reference: nil
 
   def resolve_type(%{resolve_type: nil} = interface, candidate) do

--- a/lib/absinthe/type/object.ex
+++ b/lib/absinthe/type/object.ex
@@ -1,4 +1,4 @@
-defmodule Absinthe.Type.ObjectType do
+defmodule Absinthe.Type.Object do
 
   @moduledoc """
   Represents a non-leaf node in a GraphQL tree of information.
@@ -17,7 +17,7 @@ defmodule Absinthe.Type.ObjectType do
   ```
   @absinthe :type
   def person do
-    %Absinthe.Type.ObjectType{
+    %Absinthe.Type.Object{
       fields: fields(
         name: [type: :string],
         age: [type: :integer],
@@ -30,7 +30,7 @@ defmodule Absinthe.Type.ObjectType do
 
   The "Person" type (referred inside Absinthe as `:person`) is an object, with
   fields that use `Absinthe.Type.Scalar` types (namely `:name` and `:age`), and
-  other `Absinthe.Type.ObjectType` types (`:best_friend` and `:pets`, assuming
+  other `Absinthe.Type.Object` types (`:best_friend` and `:pets`, assuming
   `:pet` is an object).
 
   Given we have a query that supports getting a person by name

--- a/lib/absinthe/type/scalar.ex
+++ b/lib/absinthe/type/scalar.ex
@@ -6,7 +6,7 @@ defmodule Absinthe.Type.Scalar do
   GraphQL responses take the form of a hierarchical tree; the leaves on these
   trees are scalars.
 
-  Also see `Absinthe.Type.ObjectType`.
+  Also see `Absinthe.Type.Object`.
 
   ## Built-In Scalars
 

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -8,7 +8,7 @@ defmodule Absinthe.Type.Union do
   @typedoc false
   @type t :: %{name: binary,
                description: binary,
-               resolve_type: ((t, any) -> Absinthe.Type.ObjectType.t),
+               resolve_type: ((t, any) -> Absinthe.Type.Object.t),
                types: [Absinthe.Type.t],
                reference: Type.Reference.t}
 

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -1,8 +1,8 @@
 Nonterminals
   Document
   Definitions Definition OperationDefinition FragmentDefinition TypeDefinition
-  ObjectTypeDefinition InterfaceTypeDefinition UnionTypeDefinition
-  ScalarTypeDefinition EnumTypeDefinition InputObjectTypeDefinition TypeExtensionDefinition
+  ObjectDefinition InterfaceDefinition UnionTypeDefinition
+  ScalarTypeDefinition EnumTypeDefinition InputObjectDefinition TypeExtensionDefinition
   FieldDefinitionList FieldDefinition ImplementsInterfaces ArgumentsDefinition
   InputValueDefinitionList InputValueDefinition UnionMembers
   EnumValueDefinitionList EnumValueDefinition
@@ -147,18 +147,18 @@ ObjectFields -> ObjectField : ['$1'].
 ObjectFields -> ObjectField ObjectFields : ['$1'|'$2'].
 ObjectField -> Name ':' Value : build_ast_node('ObjectField', #{'name' => extract_binary('$1'), 'value' => '$3'}, #{'start_line' => extract_line('$1')}).
 
-TypeDefinition -> ObjectTypeDefinition : '$1'.
-TypeDefinition -> InterfaceTypeDefinition : '$1'.
+TypeDefinition -> ObjectDefinition : '$1'.
+TypeDefinition -> InterfaceDefinition : '$1'.
 TypeDefinition -> UnionTypeDefinition : '$1'.
 TypeDefinition -> ScalarTypeDefinition : '$1'.
 TypeDefinition -> EnumTypeDefinition : '$1'.
-TypeDefinition -> InputObjectTypeDefinition : '$1'.
+TypeDefinition -> InputObjectDefinition : '$1'.
 TypeDefinition -> TypeExtensionDefinition : '$1'.
 
-ObjectTypeDefinition -> 'type' Name '{' FieldDefinitionList '}' :
-  build_ast_node('ObjectTypeDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, #{'start_line' => extract_line('$1'), 'end_line' => extract_line('$5')}).
-ObjectTypeDefinition -> 'type' Name ImplementsInterfaces '{' FieldDefinitionList '}' :
-  build_ast_node('ObjectTypeDefinition', #{'name' => extract_binary('$2'), 'interfaces' => '$3', 'fields' => '$5'}, #{'start_line' => extract_line('$1'), 'end_line' => extract_line('$6')}).
+ObjectDefinition -> 'type' Name '{' FieldDefinitionList '}' :
+  build_ast_node('ObjectDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, #{'start_line' => extract_line('$1'), 'end_line' => extract_line('$5')}).
+ObjectDefinition -> 'type' Name ImplementsInterfaces '{' FieldDefinitionList '}' :
+  build_ast_node('ObjectDefinition', #{'name' => extract_binary('$2'), 'interfaces' => '$3', 'fields' => '$5'}, #{'start_line' => extract_line('$1'), 'end_line' => extract_line('$6')}).
 
 ImplementsInterfaces -> 'implements' NamedTypeList : '$2'.
 
@@ -178,8 +178,8 @@ InputValueDefinitionList -> InputValueDefinition InputValueDefinitionList : ['$1
 InputValueDefinition -> Name ':' Type : build_ast_node('InputValueDefinition', #{'name' => extract_binary('$1'), 'type' => '$3'}, #{'start_line' => extract_line('$1')}).
 InputValueDefinition -> Name ':' Type DefaultValue : build_ast_node('InputValueDefinition', #{'name' => extract_binary('$1'), 'type' => '$3', 'default_value' => '$4'}, #{'start_line' => extract_line('$1')}).
 
-InterfaceTypeDefinition -> 'interface' Name '{' FieldDefinitionList '}' :
-  build_ast_node('InterfaceTypeDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, #{'start_line' => extract_line('$1'), 'end_line' => extract_line('$5')}).
+InterfaceDefinition -> 'interface' Name '{' FieldDefinitionList '}' :
+  build_ast_node('InterfaceDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, #{'start_line' => extract_line('$1'), 'end_line' => extract_line('$5')}).
 
 UnionTypeDefinition -> 'union' Name '=' UnionMembers :
   build_ast_node('UnionTypeDefinition', #{'name' => extract_binary('$2'), 'types' => '$4'}, #{'start_line' => extract_line('$1')}).
@@ -197,10 +197,10 @@ EnumValueDefinitionList -> EnumValueDefinition EnumValueDefinitionList : ['$1'|'
 
 EnumValueDefinition -> EnumValue : '$1'.
 
-InputObjectTypeDefinition -> 'input' Name '{' InputValueDefinitionList '}' :
-  build_ast_node('InputObjectTypeDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, #{'start_line' => extract_line('$2'), 'end_line' => extract_line('$5')}).
+InputObjectDefinition -> 'input' Name '{' InputValueDefinitionList '}' :
+  build_ast_node('InputObjectDefinition', #{'name' => extract_binary('$2'), 'fields' => '$4'}, #{'start_line' => extract_line('$2'), 'end_line' => extract_line('$5')}).
 
-TypeExtensionDefinition -> 'extend' ObjectTypeDefinition :
+TypeExtensionDefinition -> 'extend' ObjectDefinition :
   build_ast_node('TypeExtensionDefinition', #{'definition' => '$2'}, #{'start_line' => extract_line('$1')}).
 
 Erlang code.

--- a/test/lib/absinthe/adapters/language_conventions_test.exs
+++ b/test/lib/absinthe/adapters/language_conventions_test.exs
@@ -28,7 +28,7 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
     }
 
     def query do
-      %Type.ObjectType{
+      %Type.Object{
         fields: fields(
           bad_resolution: [
             type: :field_trip,
@@ -79,7 +79,7 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
 
     @absinthe :type
     def input_location do
-      %Type.InputObjectType{
+      %Type.InputObject{
         name: "Location",
         description: "A location",
         fields: fields(
@@ -90,7 +90,7 @@ defmodule Absinthe.Adapter.LanguageConventionsTest do
 
     @absinthe :type
     def field_trip do
-      %Type.ObjectType{
+      %Type.Object{
         description: "A field_trip",
         fields: fields(
           id: [

--- a/test/lib/absinthe/type/definition_test.exs
+++ b/test/lib/absinthe/type/definition_test.exs
@@ -21,28 +21,28 @@ defmodule Absinthe.Type.DefinitionTest do
 
     assert blog_schema.query == Fixtures.query
 
-    article_field = Type.ObjectType.field(Fixtures.query, :article)
+    article_field = Type.Object.field(Fixtures.query, :article)
     assert article_field
     assert article_field.name == "article"
     article_schema_type = Schema.lookup_type(blog_schema, article_field.type)
     assert article_schema_type == Fixtures.absinthe_types[:article]
     assert article_schema_type.name == "Article"
 
-    title_field = Type.ObjectType.field(article_schema_type, :title)
+    title_field = Type.Object.field(article_schema_type, :title)
     assert title_field
     title_schema_type = Schema.lookup_type(blog_schema, title_field.type)
     assert title_field.name == "title"
     assert title_schema_type.name == "String"
 
-    author_field = Type.ObjectType.field(article_schema_type, :author)
+    author_field = Type.Object.field(article_schema_type, :author)
     author_schema_type = Schema.lookup_type(blog_schema, author_field.type)
-    recent_article_field = Type.ObjectType.field(author_schema_type, :recent_article)
+    recent_article_field = Type.Object.field(author_schema_type, :recent_article)
     assert recent_article_field.name == "recent_article"
     assert recent_article_field
     recent_article_field_type = Schema.lookup_type(blog_schema, recent_article_field.type)
     assert recent_article_field_type.name == "Article"
 
-    feed_field = Type.ObjectType.field(Fixtures.query, :feed)
+    feed_field = Type.Object.field(Fixtures.query, :feed)
     assert feed_field
     assert feed_field.name == "feed"
     feed_schema_type = Schema.lookup_type(blog_schema, feed_field.type)
@@ -61,7 +61,7 @@ defmodule Absinthe.Type.DefinitionTest do
     blog_schema = MutationSchema.schema
     assert blog_schema.mutation == Fixtures.mutation
 
-    write_mutation = Type.ObjectType.field(Fixtures.mutation, :write_article)
+    write_mutation = Type.Object.field(Fixtures.mutation, :write_article)
     assert write_mutation
     assert write_mutation.name == "write_article"
     schema_type = Schema.lookup_type(blog_schema, write_mutation.type)

--- a/test/lib/absinthe/type/fixtures.exs
+++ b/test/lib/absinthe/type/fixtures.exs
@@ -5,7 +5,7 @@ defmodule Absinthe.Type.Fixtures do
 
   @absinthe :type
   def image do
-    %Type.ObjectType{
+    %Type.Object{
       fields: fields(
         url: [type: :string],
         width: [type: :integer],
@@ -16,7 +16,7 @@ defmodule Absinthe.Type.Fixtures do
 
   @absinthe :type
   def author do
-    %Type.ObjectType{
+    %Type.Object{
       fields: fields(
         id: [type: :id],
         name: [type: :string],
@@ -34,7 +34,7 @@ defmodule Absinthe.Type.Fixtures do
 
   @absinthe :type
   def article do
-    %Type.ObjectType{
+    %Type.Object{
       fields: fields(
         id: [type: :string],
         is_published: [type: :string],
@@ -46,7 +46,7 @@ defmodule Absinthe.Type.Fixtures do
   end
 
   def query do
-    %Type.ObjectType{
+    %Type.Object{
       name: "Query",
       fields: fields(
         article: [
@@ -61,7 +61,7 @@ defmodule Absinthe.Type.Fixtures do
   end
 
   def mutation do
-    %Type.ObjectType{
+    %Type.Object{
       name: "Mutation",
       fields: fields(
         write_article: [type: :article]
@@ -71,7 +71,7 @@ defmodule Absinthe.Type.Fixtures do
 
   @absinthe :type
   def object_type do
-    %Type.ObjectType{
+    %Type.Object{
       is_type_of: fn -> true end
     }
   end

--- a/test/lib/absinthe/type_test.exs
+++ b/test/lib/absinthe/type_test.exs
@@ -15,7 +15,7 @@ defmodule Absinthe.TypeTest do
     }
 
     def query do
-      %Type.ObjectType{
+      %Type.Object{
         fields: fields(
           item: [
             type: :item,
@@ -32,7 +32,7 @@ defmodule Absinthe.TypeTest do
 
     @absinthe :type
     def item do
-      %Type.ObjectType{
+      %Type.Object{
         description: "A Basic Type",
         fields: fields(
           id: [type: :id],
@@ -43,7 +43,7 @@ defmodule Absinthe.TypeTest do
 
     @absinthe type: :author
     def person do
-      %Type.ObjectType{
+      %Type.Object{
         description: "A Person",
         fields: fields(
           id: [type: :id],
@@ -56,7 +56,7 @@ defmodule Absinthe.TypeTest do
 
     @absinthe :type
     def book do
-      %Type.ObjectType{
+      %Type.Object{
         name: "NonFictionBook",
         description: "A Book",
         fields: fields(
@@ -92,15 +92,15 @@ defmodule Absinthe.TypeTest do
       describe "without a different identifier" do
 
         it 'includes a defined entry' do
-          assert %Type.ObjectType{name: "Item"} = Absinthe.TypeTest.MyApp.absinthe_types[:item]
+          assert %Type.Object{name: "Item"} = Absinthe.TypeTest.MyApp.absinthe_types[:item]
         end
 
         describe "that defines its own name" do
-          assert %Type.ObjectType{name: "NonFictionBook"} = Absinthe.TypeTest.MyApp.absinthe_types[:book]
+          assert %Type.Object{name: "NonFictionBook"} = Absinthe.TypeTest.MyApp.absinthe_types[:book]
         end
 
         describe "that uses a name derived from the identifier" do
-          assert %Type.ObjectType{name: "Item"} = Absinthe.TypeTest.MyApp.absinthe_types[:item]
+          assert %Type.Object{name: "Item"} = Absinthe.TypeTest.MyApp.absinthe_types[:item]
         end
 
       end
@@ -108,7 +108,7 @@ defmodule Absinthe.TypeTest do
       describe "with a different identifier" do
 
         it 'includes a defined entry' do
-          assert %Type.ObjectType{name: "Author"} = Absinthe.TypeTest.MyApp.absinthe_types[:author]
+          assert %Type.Object{name: "Author"} = Absinthe.TypeTest.MyApp.absinthe_types[:author]
         end
 
       end

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -9,7 +9,7 @@ defmodule Things do
   }
 
   def mutation do
-    %Type.ObjectType{
+    %Type.Object{
       name: "RootMutation",
       fields: fields(
         update_thing: [
@@ -32,7 +32,7 @@ defmodule Things do
   end
 
   def query do
-    %Type.ObjectType{
+    %Type.Object{
       fields: fields(
         bad_resolution: [
           type: :thing,
@@ -117,7 +117,7 @@ defmodule Things do
 
   @absinthe :type
   def input_thing do
-    %Type.InputObjectType{
+    %Type.InputObject{
       description: "A thing as input",
       fields: fields(
         value: [type: :integer],
@@ -131,7 +131,7 @@ defmodule Things do
 
   @absinthe :type
   def thing do
-    %Type.ObjectType{
+    %Type.Object{
       description: "A thing",
       fields: fields(
         id: [


### PR DESCRIPTION
For naming consistency `ObjectType`, `InputObjectType`
and `InterfaceType` have been renamed to `Object`, `InputObject`
and `Interface`, respectively.

Reference: #15