### PR TITLE
Meta introspection

### DIFF
--- a/lib/absinthe/introspection/types.ex
+++ b/lib/absinthe/introspection/types.ex
@@ -10,7 +10,7 @@ defmodule Absinthe.Introspection.Types do
   @absinthe :type
   def __schema do
     %Type.Object{
-      name: "__Type",
+      name: "__Schema",
       description: "Represents a schema",
       fields: fields(
         types: [

--- a/lib/absinthe/introspection/types.ex
+++ b/lib/absinthe/introspection/types.ex
@@ -19,7 +19,6 @@ defmodule Absinthe.Introspection.Types do
             _, %{schema: schema} ->
               schema.types.by_identifier
               |> Map.values
-              |> Enum.filter(&(!match?("__" <> _, &1.name)))
               |> Flag.as(:ok)
           end
         ],

--- a/lib/absinthe/schema/interface_map.ex
+++ b/lib/absinthe/schema/interface_map.ex
@@ -13,7 +13,7 @@ defmodule Absinthe.Schema.InterfaceMap do
   # Discover the mappings of interfaces to types that implement them
   @doc false
   @spec setup(Schema.t) :: Schema.t
-  def setup(%{types: types} = schema) do
+  def setup(%{types: types, errors: []} = schema) do
     {mapping, errors} = types
     |> Enum.reduce({%{}, []}, fn
       {_, %{interfaces: _}} = implementor, acc ->
@@ -22,6 +22,9 @@ defmodule Absinthe.Schema.InterfaceMap do
         acc
     end)
     %{schema | interfaces: mapping, errors: schema.errors ++ errors}
+  end
+  def setup(schema) do
+    schema
   end
 
   # Add an entry for an implementor (ind it's interfaces, if necessary)

--- a/lib/absinthe/schema/type_map.ex
+++ b/lib/absinthe/schema/type_map.ex
@@ -48,10 +48,14 @@ defmodule Absinthe.Schema.TypeMap do
         all = result |> add_from_interfaces(types_available)
         by_name = for {_, type} <- all, into: %{}, do: {type.name, type}
         %{schema | types: struct(TypeMap, by_identifier: all, by_name: by_name)}
+        |> check_duplicates
       other ->
         other
     end
   end
+
+  @spec check_duplicates(Schema.t) :: Schema.t
+  # TODO: Check for duplicates, add errors
 
   @spec collect_types(Traversal.Node.t, Traversal.t, acc_t) :: Traversal.instruction_t
   defp collect_types(%{type: possibly_wrapped_type}, traversal, {avail, collect, errors} = acc) do

--- a/lib/absinthe/schema/verification.ex
+++ b/lib/absinthe/schema/verification.ex
@@ -7,10 +7,13 @@ defmodule Absinthe.Schema.Verification do
   alias Absinthe.Schema
 
   @spec setup(Schema.t) :: Schema.t
-  def setup(schema) do
+  def setup(%{errors: []} = schema) do
     errors = Traversal.reduce(schema, schema, [], &collect_errors/3)
     %{schema | errors: schema.errors ++ errors}
     |> Verification.Unions.check
+  end
+  def setup(schema) do
+    schema
   end
 
   # Don't allow anything named with a __ prefix

--- a/test/lib/absinthe/type/definition_test.exs
+++ b/test/lib/absinthe/type/definition_test.exs
@@ -6,13 +6,13 @@ defmodule Absinthe.Type.DefinitionTest do
   alias Absinthe.Type
 
   defmodule QuerySchema do
-    use Absinthe.Schema, type_modules: [Fixtures]
+    use Absinthe.Schema, type_modules: [Fixtures.Types]
 
     def query, do: Fixtures.query
   end
 
   it "correctly assigns type references" do
-    assert %{reference: %{module: Fixtures, identifier: :article, name: "Article"}} = Fixtures.__absinthe_info__(:types)[:article]
+    assert %{reference: %{module: Fixtures.Types, identifier: :article, name: "Article"}} = Fixtures.Types.__absinthe_info__(:types)[:article]
   end
 
   it "defines a query only schema" do
@@ -21,11 +21,13 @@ defmodule Absinthe.Type.DefinitionTest do
 
     assert blog_schema.query.name == Fixtures.query.name
 
+    assert blog_schema.errors == []
+
     article_field = Type.Object.field(Fixtures.query, :article)
     assert article_field
     assert article_field.name == "article"
     article_schema_type = Schema.lookup_type(blog_schema, article_field.type)
-    assert article_schema_type == Fixtures.__absinthe_info__(:types)[:article]
+    assert article_schema_type == Fixtures.Types.__absinthe_info__(:types)[:article]
     assert article_schema_type.name == "Article"
 
     title_field = Type.Object.field(article_schema_type, :title)
@@ -50,15 +52,17 @@ defmodule Absinthe.Type.DefinitionTest do
   end
 
   defmodule MutationSchema do
-    use Absinthe.Schema, type_modules: [Fixtures]
+    use Absinthe.Schema, type_modules: [Fixtures.Types]
 
     def query, do: Fixtures.query
     def mutation, do: Fixtures.mutation
   end
 
-
   it "defines a mutation schema" do
     blog_schema = MutationSchema.schema
+
+    assert blog_schema.errors == []
+
     assert blog_schema.mutation.name == Fixtures.mutation.name
 
     write_mutation = Type.Object.field(Fixtures.mutation, :write_article)

--- a/test/lib/absinthe/type/fixtures.exs
+++ b/test/lib/absinthe/type/fixtures.exs
@@ -1,48 +1,54 @@
 defmodule Absinthe.Type.Fixtures do
 
-  use Absinthe.Schema
+  use Absinthe.Schema, type_modules: [Types]
   alias Absinthe.Type
 
-  @absinthe :type
-  def image do
-    %Type.Object{
-      fields: fields(
-        url: [type: :string],
-        width: [type: :integer],
-        height: [type: :integer]
-      )
-    }
-  end
+  defmodule Types do
 
-  @absinthe :type
-  def author do
-    %Type.Object{
-      fields: fields(
-        id: [type: :id],
-        name: [type: :string],
-        recent_article: [type: :article],
-        pic: [
-          type: :image,
-          args: args(
-            width: [type: :integer],
-            height: [type: :integer]
-          )
-        ]
-      )
-    }
-  end
+    use Absinthe.Type.Definitions
 
-  @absinthe :type
-  def article do
-    %Type.Object{
-      fields: fields(
-        id: [type: :string],
-        is_published: [type: :string],
-        author: [type: :author],
-        title: [type: :string],
-        body: [type: :string]
-      )
-    }
+    @absinthe :type
+    def image do
+      %Type.Object{
+        fields: fields(
+          url: [type: :string],
+          width: [type: :integer],
+          height: [type: :integer]
+        )
+      }
+    end
+
+    @absinthe :type
+    def author do
+      %Type.Object{
+        fields: fields(
+          id: [type: :id],
+          name: [type: :string],
+          recent_article: [type: :article],
+          pic: [
+            type: :image,
+            args: args(
+              width: [type: :integer],
+              height: [type: :integer]
+            )
+          ]
+        )
+      }
+    end
+
+    @absinthe :type
+    def article do
+      %Type.Object{
+        fields: fields(
+          id: [type: :string],
+          is_published: [type: :string],
+          author: [type: :author],
+          title: [type: :string],
+          body: [type: :string]
+        )
+      }
+    end
+
   end
 
   def query do
@@ -66,13 +72,6 @@ defmodule Absinthe.Type.Fixtures do
       fields: fields(
         write_article: [type: :article]
       )
-    }
-  end
-
-  @absinthe :type
-  def object_type do
-    %Type.Object{
-      is_type_of: fn -> true end
     }
   end
 

--- a/test/specification/introspection/schema/schema_test.exs
+++ b/test/specification/introspection/schema/schema_test.exs
@@ -12,7 +12,7 @@ defmodule Absinthe.Specification.Introspection.Schema.SchemaTest do
         ContactSchema
       )
       names = types |> Enum.map(&(&1["name"])) |> Enum.sort
-      expected = ~w(Int ID String Boolean Float Contact Person Business ProfileInput SearchResult NamedEntity RootMutationType RootQueryType __Directive __EnumValue __Field __InputValue __Type) |> Enum.sort
+      expected = ~w(Int ID String Boolean Float Contact Person Business ProfileInput SearchResult NamedEntity RootMutationType RootQueryType __Schema __Directive __EnumValue __Field __InputValue __Type) |> Enum.sort
       assert expected == names
     end
 

--- a/test/specification/introspection/schema/schema_test.exs
+++ b/test/specification/introspection/schema/schema_test.exs
@@ -12,7 +12,7 @@ defmodule Absinthe.Specification.Introspection.Schema.SchemaTest do
         ContactSchema
       )
       names = types |> Enum.map(&(&1["name"])) |> Enum.sort
-      expected = ~w(Int ID String Boolean Float Contact Person Business ProfileInput SearchResult NamedEntity RootMutationType RootQueryType) |> Enum.sort
+      expected = ~w(Int ID String Boolean Float Contact Person Business ProfileInput SearchResult NamedEntity RootMutationType RootQueryType __Directive __EnumValue __Field __InputValue __Type) |> Enum.sort
       assert expected == names
     end
 


### PR DESCRIPTION
Provide introspection types for introspection.

This also supports reporting name/identifier collisions when creating the type map.

Resolves #36.