### PR TITLE
Pass more information to resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.5.0
+
+The following changes are required if you're upgrading from the previous version:
+
+### Resolution Functions
+
+The second argument passed to resolution functions has changed from
+`Absinthe.Execution.t` to a flatter, simpler data structure,
+`Absinthe.Execution.Field.t`. This struct will be a more carefully curated
+selection of metadata and match more closely to values in the JS
+reference implementation.
+
+See the typedoc for information about `Absinthe.Execution.Field.t`, and change
+any advanced resolvers to use this new struct. The most likely change will be
+the use of `source` instead of `resolution.target`.
+
 ## v0.4.0
 
 The following changes are required if you're upgrading from the previous version:

--- a/lib/absinthe/execution.ex
+++ b/lib/absinthe/execution.ex
@@ -20,8 +20,8 @@ defmodule Absinthe.Execution do
   @typedoc "The canonical result representation of an execution"
   @type result_t :: %{data: %{binary => any}, errors: [error_t]} | %{data: %{binary => any}} | %{errors: [error_t]}
 
-  @type t :: %{schema: Schema.t, document: Language.Document.t, variables: map, selected_operation: Absinthe.Type.Object.t, operation_name: binary, errors: [error_t], categorized: boolean, strategy: atom, adapter: atom, resolution: Execution.Resolution.t}
-  defstruct schema: nil, document: nil, variables: %{}, fragments: %{}, operations: %{}, selected_operation: nil, operation_name: nil, errors: [], categorized: false, strategy: nil, adapter: nil, resolution: nil
+  @type t :: %{schema: Schema.t, document: Language.Document.t, variables: map, selected_operation: Absinthe.Type.Object.t, operation_name: binary, errors: [error_t], categorized: boolean, strategy: atom, adapter: atom, resolution: Execution.Resolution.t, context: map, root: any}
+  defstruct schema: nil, document: nil, variables: %{}, fragments: %{}, operations: %{}, selected_operation: nil, operation_name: nil, errors: [], categorized: false, strategy: nil, adapter: nil, resolution: nil, context: %{}, root: nil
 
   @doc false
   def run(execution, options \\ []) do

--- a/lib/absinthe/execution.ex
+++ b/lib/absinthe/execution.ex
@@ -20,8 +20,8 @@ defmodule Absinthe.Execution do
   @typedoc "The canonical result representation of an execution"
   @type result_t :: %{data: %{binary => any}, errors: [error_t]} | %{data: %{binary => any}} | %{errors: [error_t]}
 
-  @type t :: %{schema: Schema.t, document: Language.Document.t, variables: map, selected_operation: Absinthe.Type.Object.t, operation_name: binary, errors: [error_t], categorized: boolean, strategy: atom, adapter: atom, resolution: Execution.Resolution.t, context: map, root: any}
-  defstruct schema: nil, document: nil, variables: %{}, fragments: %{}, operations: %{}, selected_operation: nil, operation_name: nil, errors: [], categorized: false, strategy: nil, adapter: nil, resolution: nil, context: %{}, root: nil
+  @type t :: %{schema: Schema.t, document: Language.Document.t, variables: map, selected_operation: Absinthe.Type.Object.t, operation_name: binary, errors: [error_t], categorized: boolean, strategy: atom, adapter: atom, resolution: Execution.Resolution.t, context: map, root_value: any}
+  defstruct schema: nil, document: nil, variables: %{}, fragments: %{}, operations: %{}, selected_operation: nil, operation_name: nil, errors: [], categorized: false, strategy: nil, adapter: nil, resolution: nil, context: %{}, root_value: nil
 
   @doc false
   def run(execution, options \\ []) do

--- a/lib/absinthe/execution/field.ex
+++ b/lib/absinthe/execution/field.ex
@@ -8,16 +8,17 @@ defmodule Absinthe.Execution.Field do
   @typedoc """
 
   ## Options
-  - `:adapter` - The execution adapter
+  - `:adapter` - The execution adapter.
   - `:ast_node` - The current AST node.
   - `:context` - The context passed to `Absinthe.run`.
-  - `:definition` - The current field definition
-  - `:root` - The root object passed to `Absinthe.run`, if any.
+  - `:definition` - The current field definition.
+  - `:parent_type` - The parent type for the field.
+  - `:root_value` - The root value passed to `Absinthe.run`, if any.
   - `:schema` - The current schema.
   - `:source` - The resolved parent object; source of this field.
   """
-  @type t :: %{adapter: atom, ast_node: Language.t, context: map, definition: Type.Field.t, root: any, schema: Schema.t, source: any}
+  @type t :: %{adapter: atom, ast_node: Language.t, context: map, definition: Type.Field.t, parent_type: Type.t, root_value: any, schema: Schema.t, source: any}
 
-  defstruct adapter: nil, ast_node: nil, context: nil, definition: nil, root: nil, schema: nil, source: nil
+  defstruct adapter: nil, ast_node: nil, context: nil, definition: nil, parent_type: nil, root_value: nil, schema: nil, source: nil
 
 end

--- a/lib/absinthe/execution/field.ex
+++ b/lib/absinthe/execution/field.ex
@@ -8,6 +8,7 @@ defmodule Absinthe.Execution.Field do
   @typedoc """
 
   ## Options
+  - `:adapter` - The execution adapter
   - `:ast_node` - The current AST node.
   - `:context` - The context passed to `Absinthe.run`.
   - `:definition` - The current field definition
@@ -15,8 +16,8 @@ defmodule Absinthe.Execution.Field do
   - `:schema` - The current schema.
   - `:source` - The resolved parent object; source of this field.
   """
-  @type t :: %{ast_node: Language.t, context: map, definition: Type.Field.t, root: any, schema: Schema.t, source: any}
+  @type t :: %{adapter: atom, ast_node: Language.t, context: map, definition: Type.Field.t, root: any, schema: Schema.t, source: any}
 
-  defstruct ast_node: nil, context: nil, definition: nil, root: nil, schema: nil, source: nil
+  defstruct adapter: nil, ast_node: nil, context: nil, definition: nil, root: nil, schema: nil, source: nil
 
 end

--- a/lib/absinthe/execution/field.ex
+++ b/lib/absinthe/execution/field.ex
@@ -1,0 +1,22 @@
+defmodule Absinthe.Execution.Field do
+
+  @moduledoc """
+  Information passed to aid resolution functions, describing the current field's
+  execution environment.
+  """
+
+  @typedoc """
+
+  ## Options
+  - `:ast_node` - The current AST node.
+  - `:context` - The context passed to `Absinthe.run`.
+  - `:definition` - The current field definition
+  - `:root` - The root object passed to `Absinthe.run`, if any.
+  - `:schema` - The current schema.
+  - `:source` - The resolved parent object; source of this field.
+  """
+  @type t :: %{ast_node: Language.t, context: map, definition: Type.Field.t, root: any, schema: Schema.t, source: any}
+
+  defstruct ast_node: nil, context: nil, definition: nil, root: nil, schema: nil, source: nil
+
+end

--- a/lib/absinthe/execution/resolution.ex
+++ b/lib/absinthe/execution/resolution.ex
@@ -1,5 +1,7 @@
 defprotocol Absinthe.Execution.Resolution do
 
+  @moduledoc false
+
   alias Absinthe.Language
   alias Absinthe.Type
 

--- a/lib/absinthe/execution/resolution/field.ex
+++ b/lib/absinthe/execution/resolution/field.ex
@@ -4,20 +4,20 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.Field do
   alias Absinthe.Execution.Resolution
   alias Absinthe.Type
   alias Absinthe.Flag
+  alias Absinthe.Language
   alias Absinthe.Introspection
 
   @spec resolve(Absinthe.Language.Field.t,
                 Absinthe.Execution.t) :: {:ok, map} | {:error, any}
   def resolve(%{name: name} = ast_node, %{strategy: :serial, resolution: %{parent_type: parent_type, target: target}} = execution) do
     field = Type.field(parent_type, ast_node.name)
-    execution_field = %Execution.Field{adapter: execution.adapter, ast_node: ast_node, context: execution.context, definition: field, root: execution.root, schema: execution.schema, source: target}
     case field do
       %{resolve: nil} ->
         target |> Map.get(name |> String.to_atom) |> result(ast_node, field, execution)
       %{resolve: resolver} ->
         case Execution.Arguments.build(ast_node, field.args, execution) do
           {:ok, args, exe} ->
-            resolver.(args, execution_field)
+            resolver.(args, environment(field, ast_node, execution))
             |> process_raw_result(ast_node, field, exe)
           {:error, {missing, invalid}, exe} ->
             exe
@@ -34,6 +34,22 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.Field do
           |> Flag.as(:skip)
         end
     end
+  end
+
+  # Build a `Absinthe.Execution.Field` struct containing the resolution environment
+  # of the field
+  @spec environment(Type.Field.t, Language.t, Execution.t) :: Execution.Field.t
+  defp environment(field, ast_node, execution) do
+    %Execution.Field{
+      adapter: execution.adapter,
+      ast_node: ast_node,
+      context: execution.context,
+      definition: field,
+      parent_type: execution.resolution.parent_type,
+      root_value: execution.root_value,
+      schema: execution.schema,
+      source: execution.resolution.target
+    }
   end
 
   defp skip_as(execution, _reason, [], _name, _ast_node) do

--- a/lib/absinthe/execution/resolution/field.ex
+++ b/lib/absinthe/execution/resolution/field.ex
@@ -10,13 +10,14 @@ defimpl Absinthe.Execution.Resolution, for: Absinthe.Language.Field do
                 Absinthe.Execution.t) :: {:ok, map} | {:error, any}
   def resolve(%{name: name} = ast_node, %{strategy: :serial, resolution: %{parent_type: parent_type, target: target}} = execution) do
     field = Type.field(parent_type, ast_node.name)
+    execution_field = %Execution.Field{adapter: execution.adapter, ast_node: ast_node, context: execution.context, definition: field, root: execution.root, schema: execution.schema, source: target}
     case field do
       %{resolve: nil} ->
         target |> Map.get(name |> String.to_atom) |> result(ast_node, field, execution)
       %{resolve: resolver} ->
         case Execution.Arguments.build(ast_node, field.args, execution) do
           {:ok, args, exe} ->
-            resolver.(args, exe)
+            resolver.(args, execution_field)
             |> process_raw_result(ast_node, field, exe)
           {:error, {missing, invalid}, exe} ->
             exe

--- a/lib/absinthe/introspection/field.ex
+++ b/lib/absinthe/introspection/field.ex
@@ -11,17 +11,17 @@ defmodule Absinthe.Introspection.Field do
       type: :string,
       description: "The name of the object type currently being queried.",
       resolve: fn
-        _, %{resolution: %{parent_type: %Type.Object{} = type}} ->
+        _, %{parent_type: %Type.Object{} = type} ->
           {:ok, type.name}
-        _, %{resolution: %{target: target, parent_type: %Type.Interface{} = iface}} = exe ->
-          case Type.Interface.resolve_type(iface, target, exe) do
+        _, %{source: source, parent_type: %Type.Interface{} = iface} = env ->
+          case Type.Interface.resolve_type(iface, source, env) do
             nil ->
               {:error, "Could not resolve type of concrete " <> iface.name}
             type ->
               {:ok, type.name}
           end
-        _, %{resolution: %{target: target, parent_type: %Type.Union{} = union}} = exe ->
-          case Type.Union.resolve_type(union, target, exe) do
+        _, %{source: source, parent_type: %Type.Union{} = union} = env ->
+          case Type.Union.resolve_type(union, source, env) do
             nil ->
               {:error, "Could not resolve type of concrete " <> union.name}
             type ->

--- a/lib/absinthe/type/field.ex
+++ b/lib/absinthe/type/field.ex
@@ -70,7 +70,7 @@ defmodule Absinthe.Type.Field do
                 location_id: [type: non_null(:integer)]
               ),
               resolve: fn
-                %{location_id: id}, _execution ->
+                %{location_id: id}, _ ->
                   {:ok, MyApp.users_for_location_id(id)}
               end
             ]
@@ -82,8 +82,9 @@ defmodule Absinthe.Type.Field do
 
   1. A map of the arguments for the field, filled in with values from the
      provided query document/variables.
-  2. An `Absinthe.Execution` struct, containing the complete execution context
-     (and useful for complex resolutions using the resolved parent object, etc)
+  2. An `Absinthe.Execution.Field` struct, containing the execution environment
+     for the field (and useful for complex resolutions using the resolved source
+     object, etc)
 
   """
   @type t :: %{name: binary,
@@ -92,7 +93,7 @@ defmodule Absinthe.Type.Field do
                deprecation: Deprecation.t | nil,
                default_value: any,
                args: %{(binary | atom) => Absinthe.Type.Argument.t} | nil,
-               resolve: ((any, %{binary => any} | nil, Absinthe.Type.ResolveInfo.t | nil) -> Absinthe.Type.output_t) | nil}
+               resolve: ((%{atom => any}, Absinthe.Execution.Field.t) -> {:ok, any} | {:error, binary}) | nil}
 
   defstruct name: nil, description: nil, type: nil, deprecation: nil, args: %{}, resolve: nil, default_value: nil
 

--- a/lib/absinthe/type/interface.ex
+++ b/lib/absinthe/type/interface.ex
@@ -76,7 +76,7 @@ defmodule Absinthe.Type.Interface do
   defstruct name: nil, description: nil, fields: nil, resolve_type: nil, reference: nil
 
 
-  @spec resolve_type(Type.Interface.t, any, Execution.t) :: Type.t | nil
+  @spec resolve_type(Type.Interface.t, any, Execution.Field.t) :: Type.t | nil
   def resolve_type(%{resolve_type: nil, reference: %{identifier: ident}}, obj, %{schema: schema}) do
     implementors = schema.interfaces[ident]
     Enum.find(implementors, fn
@@ -86,8 +86,8 @@ defmodule Absinthe.Type.Interface do
         type.is_type_of.(obj)
     end)
   end
-  def resolve_type(%{resolve_type: resolver}, obj, %{schema: schema} = exe) do
-    case resolver.(obj, exe) do
+  def resolve_type(%{resolve_type: resolver}, obj, %{schema: schema} = env) do
+    case resolver.(obj, env) do
       nil ->
         nil
       ident when is_atom(ident) ->

--- a/lib/absinthe/type/union.ex
+++ b/lib/absinthe/type/union.ex
@@ -55,7 +55,7 @@ defmodule Absinthe.Type.Union do
   end
 
   @doc false
-  @spec resolve_type(t, any, Execution.t) :: Type.t | nil
+  @spec resolve_type(t, any, Execution.Field.t) :: Type.t | nil
   def resolve_type(%{resolve_type: nil, types: types}, obj, %{schema: schema}) do
     Enum.find(types, fn
       %{is_type_of: nil} ->
@@ -65,8 +65,8 @@ defmodule Absinthe.Type.Union do
         type_struct.is_type_of.(obj)
     end)
   end
-  def resolve_type(%{resolve_type: resolver}, obj, %{schema: schema} = exe) do
-    case resolver.(obj, exe) do
+  def resolve_type(%{resolve_type: resolver}, obj, %{schema: schema} = env) do
+    case resolver.(obj, env) do
       nil ->
         nil
       ident when is_atom(ident) ->

--- a/test/support/things.ex
+++ b/test/support/things.ex
@@ -148,7 +148,7 @@ defmodule Things do
         ],
         other_thing: [
           type: :thing,
-          resolve: fn (_, %{resolution: %{target: %{id: id}}}) ->
+          resolve: fn (_, %{source: %{id: id}}) ->
             case id do
               "foo" -> {:ok, @db |> Map.get("bar")}
               "bar" -> {:ok, @db |> Map.get("foo")}


### PR DESCRIPTION
To support #43.

Add a `Absinthe.Execution.Field` struct to be passed to every resolver as the second argument. This struct will contain:

  - `:adapter` (`:: atom`) The adapter
  - `:ast_node` - (`:: Absinthe.Language.t`) The current AST node.
  - `:context` - (`:: map`) The context passed to `Absinthe.run`.
  - `:definition` - (`:: Absinthe.Type.Field.t`) The current field definition
  - `:root` - (`:: any`) The root object passed to `Absinthe.run`, if any.
  - `:schema` - (`:: Absinthe.Schema.t`) The current schema.
  - `:source` - (`:: any`) The resolved parent object; source of this field.