### PR TITLE
Add “variables” keyword to Absinthe run_opts type

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -83,6 +83,7 @@ defmodule Absinthe do
           root_value: term,
           operation_name: String.t(),
           analyze_complexity: boolean,
+          variables: %{optional(String.t) => any()},
           max_complexity: non_neg_integer | :infinity
         ]
 


### PR DESCRIPTION
Add the missing variables keyword to the run_opts of `Absinthe.run`. Dialyzer allows the `variables` keyword when using `Absinthe.run`.