### PR TITLE
Default values wheren't rendered in the sdl

### DIFF
--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -107,7 +107,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       string(@adapter.to_external_name(input_value.name, :argument)),
       ": ",
       render(input_value.type, type_definitions),
-      default(input_value.default_value_blueprint),
+      default(input_value.default_value_blueprint || %{value: input_value.default_value}),
       directives(input_value.directives, type_definitions)
     ])
     |> description(input_value.description)
@@ -339,6 +339,10 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
   end
 
   defp default(nil) do
+    empty()
+  end
+
+  defp default(%{value: nil}) do
     empty()
   end
 

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -197,6 +197,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
       field :echo, :string do
         arg :times, :integer, default_value: 10, description: "The number of times"
         arg :time_interval, :integer
+        arg :time_string, :string, default_value: "2021"
       end
 
       field :search, :search_result
@@ -251,9 +252,10 @@ defmodule Absinthe.Schema.SdlRenderTest do
              type RootQueryType {
                echo(
                  "The number of times"
-                 times: Int
+                 times: Int = 10
 
                  timeInterval: Int
+                 timeString: String = "2021"
                ): String
                search: SearchResult
              }


### PR DESCRIPTION
When setting default values on input args they aren't rendered in the final sdl.