### PR TITLE
Replace put_opts with put_options in Subscriptions guide

### DIFF
--- a/guides/subscriptions.md
+++ b/guides/subscriptions.md
@@ -116,7 +116,7 @@ defmodule MyAppWeb.UserSocket do
 
   def connect(params, socket) do
     current_user = current_user(params)
-    socket = Absinthe.Phoenix.Socket.put_opts(socket, context: %{
+    socket = Absinthe.Phoenix.Socket.put_options(socket, context: %{
       current_user: current_user
     })
     {:ok, socket}


### PR DESCRIPTION
`put_opts` is deprecated since `absinthe_phoenix` v1.4.1.

<!--

### Precheck

Thank you for submitting a pull request! Absinthe is a large
project, and we really appreciate your help improving it.

Please keep the following in mind as you submit your code; it
will help us review, discuss, and merge your PR as quickly
as possible.

- Tests are good! Please include them if possible.
- Documentation is good:
  - Modules should have a `@moduledoc` (may be `false`)
  - Public functions should have a `@doc` (may be `false`)
  - Consider checking `/guides` for documentation that
    needs to be updated
- Specifications are good. Include `@spec` when possible.
- Good Git history behavior is good. Don't rebase your PR branch,
  and make small, focused commits. We generally squash commits on
  merge for you, unless there is a reason not to (multiple committers
  on a PR, etc).
- Matching existing code style is good.

We're happy to work with you, providing guidance and assistance
where we can, collaborating with you to help your contribution become
part of Absinthe. Thanks again!

As always, feel free to reach out for questions/discussion via:

- Our Slack channel (#absinthe-graphql): https://elixir-slackin.herokuapp.com
- The Elixir Forum: https://elixirforum.com

-->
