### PR TITLE
Store the document only once when several field keys are supplied

### DIFF
--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -25,8 +25,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
       field_keys = get_field_keys(field, config)
       subscription_id = get_subscription_id(config, blueprint, options)
 
-      for field_key <- field_keys,
-          do: Absinthe.Subscription.subscribe(pubsub, field_key, subscription_id, blueprint)
+      Absinthe.Subscription.subscribe(pubsub, field_keys, subscription_id, blueprint)
 
       {:replace, blueprint,
        [


### PR DESCRIPTION
Follow up to #1268 which further optimizes registry storage when a single subscription document subscribes to multiple field keys.