### PR TITLE
feat: Support module concat in middleware to avoid compile-time dependencies

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -1873,6 +1873,10 @@ defmodule Absinthe.Schema.Notation do
               {:{}, [], [{env.module, atom}, opts]}
           end
 
+        # Special handling for Module.concat to allow breaking of compilation cycles
+        {{:., _meta, [Module, :concat]}, _call_meta, _args} = val ->
+          {:{}, [], [{val, :call}, opts]}
+
         val ->
           val
       end


### PR DESCRIPTION
This allows using `Module.concat/1,2` to provide the middleware. The benefit of this is that the resolver no longer has a compile-time dependency on the middleware, and more importantly a transitive dependency on all the middleware's runtime dependencies.

Here is an example of a supported field definition:
```elixir
field :folder, non_null(:folder) do
  arg :id, non_null(:string)
  middleware Module.concat(MyAppWeb.GraphQL, MyMiddleware), some_options: [42]
  resolve &SomeResolver.project_folder/3
end
```

This almost works today, but `MyMiddleware` doesn't receive the provided options.

Fix is related to https://github.com/absinthe-graphql/absinthe/issues/1359

This is more of a PoC/RFC right now. We may actually want to go with an approach that targets the compiler directly, like these two related ecto commits:
- https://github.com/elixir-ecto/ecto/pull/1670
- https://github.com/elixir-ecto/ecto/commit/cadaced80a4fe200f21003da111ce801b48d1c07