### PR TITLE
fix:  Error return when struct

### DIFF
--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -409,7 +409,8 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     end
   end
 
-  defp split_error_value(error_value) when is_list(error_value) or is_map(error_value) do
+  defp split_error_value(error_value)
+       when is_list(error_value) or (is_map(error_value) and not is_struct(error_value)) do
     Keyword.split(Enum.to_list(error_value), [:message, :path])
   end
 


### PR DESCRIPTION
When returning a struct implementing to_string an exception will be thrown on Enum.to_list, because structs passes the is_map/1 gaurd and Enum.to_list fails on structs. In these cases it needs to fall back to to_string.

In Elixir 1.17 we can use is_non_struct_map/1, but think it won't be worth updating the minimum Elixir version for this.

I don't see any test for this part, so happy to add if someone can point me to a test to add/update. 