### PR TITLE
fix: render default values in SDL output for schema.sdl task

### DIFF
--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -324,12 +324,8 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
         concat([" = ", string(enum_name)])
 
       :error ->
-        try do
-          blueprint_value = Blueprint.Input.parse(default_value)
-          concat([" = ", render_value(blueprint_value)])
-        rescue
-          _ -> empty()
-        end
+        blueprint_value = Blueprint.Input.parse(default_value)
+        concat([" = ", render_value(blueprint_value)])
     end
   end
 
@@ -339,12 +335,8 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
        )
        when is_binary(default_value) or is_number(default_value) or is_boolean(default_value) or
               is_list(default_value) or is_map(default_value) do
-    try do
-      blueprint_value = Blueprint.Input.parse(default_value)
-      concat([" = ", render_value(blueprint_value)])
-    rescue
-      _ -> empty()
-    end
+    blueprint_value = Blueprint.Input.parse(default_value)
+    concat([" = ", render_value(blueprint_value)])
   end
 
   defp default(%Blueprint.Schema.FieldDefinition{}, _type_definitions) do

--- a/lib/absinthe/schema/notation/sdl_render.ex
+++ b/lib/absinthe/schema/notation/sdl_render.ex
@@ -70,7 +70,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
       string(@adapter.to_external_name(input_value.name, :argument)),
       ": ",
       render(input_value.type, type_definitions),
-      default(input_value.default_value_blueprint),
+      default(input_value, type_definitions),
       directives(input_value.directives, type_definitions)
     ])
     |> description(input_value.description)
@@ -107,7 +107,7 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
         string(input_object_type.name),
         directives(input_object_type.directives, type_definitions)
       ]),
-      render_list(input_object_type.fields, type_definitions)
+      render_input_fields(input_object_type.fields, type_definitions)
     )
     |> description(input_object_type.description)
   end
@@ -306,13 +306,118 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
     )
   end
 
-  defp default(nil) do
+  defp default(%Blueprint.Schema.FieldDefinition{default_value: nil}, _type_definitions) do
     empty()
   end
 
-  defp default(default_value) do
-    concat([" = ", render_value(default_value)])
+  defp default(%Blueprint.Schema.FieldDefinition{default_value: {:ref, _, _}}, _type_definitions) do
+    empty()
   end
+
+  defp default(
+         %Blueprint.Schema.FieldDefinition{type: type, default_value: default_value},
+         type_definitions
+       )
+       when is_atom(default_value) do
+    case find_enum_value_name(type, default_value, type_definitions) do
+      {:ok, enum_name} ->
+        concat([" = ", string(enum_name)])
+
+      :error ->
+        try do
+          blueprint_value = Blueprint.Input.parse(default_value)
+          concat([" = ", render_value(blueprint_value)])
+        rescue
+          _ -> empty()
+        end
+    end
+  end
+
+  defp default(
+         %Blueprint.Schema.FieldDefinition{default_value: default_value},
+         _type_definitions
+       )
+       when is_binary(default_value) or is_number(default_value) or is_boolean(default_value) or
+              is_list(default_value) or is_map(default_value) do
+    try do
+      blueprint_value = Blueprint.Input.parse(default_value)
+      concat([" = ", render_value(blueprint_value)])
+    rescue
+      _ -> empty()
+    end
+  end
+
+  defp default(%Blueprint.Schema.FieldDefinition{}, _type_definitions) do
+    empty()
+  end
+
+  defp default(
+         %Blueprint.Schema.InputValueDefinition{
+           default_value_blueprint: nil,
+           default_value: nil
+         },
+         _type_definitions
+       ) do
+    empty()
+  end
+
+  defp default(
+         %Blueprint.Schema.InputValueDefinition{
+           default_value_blueprint: nil,
+           default_value: default_value
+         },
+         _type_definitions
+       )
+       when not is_nil(default_value) do
+    blueprint_value = Blueprint.Input.parse(default_value)
+    concat([" = ", render_value(blueprint_value)])
+  end
+
+  defp default(
+         %Blueprint.Schema.InputValueDefinition{
+           default_value_blueprint: default_value_blueprint
+         },
+         _type_definitions
+       )
+       when not is_nil(default_value_blueprint) do
+    concat([" = ", render_value(default_value_blueprint)])
+  end
+
+  defp default(_, _) do
+    empty()
+  end
+
+  defp find_enum_value_name(type, internal_value, type_definitions) do
+    enum_identifier = unwrap_type_identifier(type)
+
+    with enum_def when not is_nil(enum_def) <-
+           Enum.find(type_definitions, &(&1.identifier == enum_identifier)),
+         %Blueprint.Schema.EnumTypeDefinition{} <- enum_def,
+         enum_value when not is_nil(enum_value) <-
+           Enum.find(List.flatten(enum_def.values), fn
+             %Blueprint.Schema.EnumValueDefinition{value: ^internal_value} -> true
+             atom when is_atom(atom) and atom == internal_value -> true
+             _ -> false
+           end) do
+      case enum_value do
+        %Blueprint.Schema.EnumValueDefinition{name: name} -> {:ok, name}
+        atom when is_atom(atom) -> {:ok, atom |> to_string() |> String.upcase()}
+      end
+    else
+      _ -> :error
+    end
+  end
+
+  defp unwrap_type_identifier(%Blueprint.TypeReference.NonNull{of_type: inner}),
+    do: unwrap_type_identifier(inner)
+
+  defp unwrap_type_identifier(%Blueprint.TypeReference.List{of_type: inner}),
+    do: unwrap_type_identifier(inner)
+
+  defp unwrap_type_identifier(%Blueprint.TypeReference.Identifier{id: id}), do: id
+  defp unwrap_type_identifier(%Blueprint.TypeReference.Name{name: name}), do: name
+  defp unwrap_type_identifier(atom) when is_atom(atom), do: atom
+  defp unwrap_type_identifier(_), do: nil
 
   defp description(docs, nil) do
     docs
@@ -355,6 +460,47 @@ defmodule Absinthe.Schema.Notation.SDL.Render do
   defp repeatable(_), do: empty()
 
   # Render Helpers
+
+  defp render_input_fields(fields, type_definitions) do
+    items = Enum.reject(fields, &(&1.module in @skip_modules))
+
+    splitter =
+      items
+      |> Enum.any?(&(&1.description not in ["", nil]))
+      |> case do
+        true -> [nest(line(), :reset), line()]
+        false -> [line()]
+      end
+
+    items
+    |> Enum.reverse()
+    |> Enum.reduce(:start, fn
+      item, :start -> render_input_field(item, type_definitions)
+      item, acc -> concat([render_input_field(item, type_definitions)] ++ splitter ++ [acc])
+    end)
+  end
+
+  defp render_input_field(%Blueprint.Schema.FieldDefinition{} = field, type_definitions) do
+    concat([
+      string(@adapter.to_external_name(field.name, :field)),
+      ": ",
+      render(field.type, type_definitions),
+      default(field, type_definitions),
+      directives(field.directives, type_definitions)
+    ])
+    |> description(field.description)
+  end
+
+  defp render_input_field(%Blueprint.Schema.InputValueDefinition{} = field, type_definitions) do
+    concat([
+      string(@adapter.to_external_name(field.name, :argument)),
+      ": ",
+      render(field.type, type_definitions),
+      default(field, type_definitions),
+      directives(field.directives, type_definitions)
+    ])
+    |> description(field.description)
+  end
 
   defp render_list(items, type_definitions, separator \\ line())
 

--- a/test/absinthe/schema/sdl_render_test.exs
+++ b/test/absinthe/schema/sdl_render_test.exs
@@ -275,7 +275,7 @@ defmodule Absinthe.Schema.SdlRenderTest do
              type RootQueryType {
                echo(
                  \"The number of times\"
-                 times: Int
+                 times: Int = 10
 
                  timeInterval: Int
                ): String

--- a/test/absinthe/schema/type_system_directive_test.exs
+++ b/test/absinthe/schema/type_system_directive_test.exs
@@ -225,7 +225,7 @@ defmodule Absinthe.Schema.TypeSystemDirectiveTest do
   }
 
   input SearchFilter @feature(name: \":input_object\") {
-    query: String @feature(name: \":input_field_definition\")
+    query: String = "default" @feature(name: \":input_field_definition\")
   }
 
   union SearchResult @feature(name: \":union\") = Dog | Post

--- a/test/mix/tasks/absinthe.schema.sdl_test.exs
+++ b/test/mix/tasks/absinthe.schema.sdl_test.exs
@@ -123,6 +123,96 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
     end
   end
 
+  defmodule DefaultValueTestSchema do
+    use Absinthe.Schema
+
+    enum :color do
+      value :red
+      value :green
+      value :blue
+    end
+
+    enum :priority do
+      value :high
+      value :medium
+      value :low
+    end
+
+    enum :status do
+      value :active
+      value :inactive
+    end
+
+    query do
+      field :item, :string do
+        arg :show, :boolean, default_value: true
+      end
+
+      field :search, :string do
+        arg :filters, :filters, default_value: %{query: "mystring"}
+      end
+
+      field :enum_field, :string do
+        arg :input, :enum_input
+      end
+
+      field :sorted_items, :string do
+        arg :input, :sort_input
+      end
+
+      field :nested_field, :string do
+        arg :input, :nested_input
+      end
+
+      field :list_field, :string do
+        arg :input, :list_input
+      end
+
+      field :optional_field, :string do
+        arg :input, :optional_input
+      end
+    end
+
+    mutation do
+      field :create_item, :string do
+        arg :input, non_null(:test_input)
+        arg :other, :string, default_value: "other"
+      end
+    end
+
+    input_object :filters do
+      field :query, :string
+    end
+
+    input_object :test_input do
+      field :value, non_null(:string), default_value: "test"
+    end
+
+    input_object :enum_input do
+      field :name, non_null(:string)
+      field :color, :color, default_value: :red
+    end
+
+    input_object :sort_input do
+      field :priority, :priority, default_value: :high
+      field :include_archived, :boolean, default_value: false
+    end
+
+    input_object :nested_input do
+      field :status, :status, default_value: :active
+    end
+
+    input_object :list_input do
+      field :items, list_of(:string), default_value: ["test"]
+      field :default_status, :status, default_value: :inactive
+    end
+
+    input_object :optional_input do
+      field :optional_status, :status
+      field :required_status, non_null(:status), default_value: :active
+    end
+  end
+
   @test_mod_schema "Mix.Tasks.Absinthe.Schema.SdlTest.TestSchemaWithMods"
 
   setup_all do
@@ -192,6 +282,31 @@ defmodule Mix.Tasks.Absinthe.Schema.SdlTest do
       assert Task.run(argv)
 
       assert File.exists?(path)
+    end
+
+    test "with default values including enums" do
+      argv = ["output.graphql", "--schema", "#{DefaultValueTestSchema}"]
+      opts = Task.parse_options(argv)
+
+      {:ok, schema} = Task.generate_schema(opts)
+
+      assert schema =~ "value: String! = \"test\""
+      assert schema =~ "other: String = \"other\""
+      assert schema =~ "show: Boolean = true"
+      assert schema =~ "filters: Filters = {query: \"mystring\"}"
+      assert schema =~ "input EnumInput {"
+      assert schema =~ "color: Color = RED"
+      assert schema =~ "input SortInput {"
+      assert schema =~ "priority: Priority = HIGH"
+      assert schema =~ "includeArchived: Boolean = false"
+      assert schema =~ "input NestedInput {"
+      assert schema =~ "status: Status = ACTIVE"
+      assert schema =~ "input ListInput {"
+      assert schema =~ ~s(items: [String] = ["test"])
+      assert schema =~ "defaultStatus: Status = INACTIVE"
+      assert schema =~ "input OptionalInput {"
+      assert schema =~ "optionalStatus: Status"
+      assert schema =~ "requiredStatus: Status! = ACTIVE"
     end
   end
 end


### PR DESCRIPTION
Fixes #1222

Previously, the `mix absinthe.schema.sdl` task would not include default values for arguments and input object fields in the generated SDL output, even though the `mix absinthe.schema.json` task would properly include them in its output.

Changes:
- Modified SDL renderer to handle default values for InputValueDefinition (arguments) and FieldDefinition (input object fields)
- Added support for DSL-defined schemas where default_value is an Elixir term that needs conversion to Blueprint.Input structures
- Added support for SDL-parsed schemas where default_value_blueprint is already a Blueprint structure
- Skip non-serializable values (refs, functions)

Tests:
- Added DefaultValueTestSchema with default value coverage to prevent regression while rendering boolean, string, and input object default values
- All existing tests updated to expect default values in output. There were 2 that confirmed this behavior wasn't working
- We integrated this change into our production app, and have validated the expected outcomes against a significantly large schema that also employs the federation extensions.

Note:

Hit #1083 quite a bit, will see if I can address in a separate PR.