### PR TITLE
fix: Handle missing registry in Subscription.unsubscribe/2 during shutdown

### DIFF
--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -179,11 +179,13 @@ defmodule Absinthe.Subscription do
   def unsubscribe(pubsub, doc_id) do
     registry = pubsub |> registry_name
 
-    for field_key <- pdict_fields(doc_id) do
-      Registry.unregister_match(registry, field_key, doc_id)
-    end
+    if Process.whereis(registry) do
+      for field_key <- pdict_fields(doc_id) do
+        Registry.unregister_match(registry, field_key, doc_id)
+      end
 
-    Registry.unregister(registry, doc_id)
+      Registry.unregister(registry, doc_id)
+    end
 
     pdict_delete_fields(doc_id)
     :ok

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -326,6 +326,29 @@ defmodule Absinthe.Execution.SubscriptionTest do
     refute_receive({:broadcast, _})
   end
 
+  test "unsubscribe does not raise when registry is down" do
+    # Use a dedicated pubsub/registry to avoid affecting other tests.
+    # This simulates the scenario where Absinthe.Subscription is terminated
+    # before the Endpoint during graceful shutdown (OTP terminates children
+    # in reverse start order), causing active SSE connections to call
+    # unsubscribe/2 against a registry that no longer exists.
+    pubsub = ShutdownTestPubSub
+    registry_name = Absinthe.Subscription.registry_name(pubsub)
+    Registry.start_link(keys: :duplicate, name: registry_name, partitions: 1)
+
+    doc_id = "test_doc_id"
+    field_key = "test_field_key"
+
+    {:ok, _} = Registry.register(registry_name, field_key, doc_id)
+    {:ok, _} = Registry.register(registry_name, doc_id, %{})
+    Process.put({Absinthe.Subscription, doc_id}, [field_key])
+
+    Process.flag(:trap_exit, true)
+    GenServer.stop(registry_name)
+
+    assert :ok = Absinthe.Subscription.unsubscribe(pubsub, doc_id)
+  end
+
   test "can unsubscribe from duplicate subscriptions individually" do
     client_id = "abc"
 


### PR DESCRIPTION
## Problem

When using SSE-based subscriptions (`standard_sse: true` in `absinthe_plug`), active connections call `unsubscribe/2` during connection teardown. In a standard supervision tree where `Absinthe.Subscription` is started after the Endpoint (as documented), OTP terminates children in reverse start order — meaning the subscription Registry is shut down before the Endpoint finishes draining connections.

This causes an `ArgumentError: unknown registry` from `Registry.unregister_match/4` during every deployment for each active SSE subscription.

```
Elixir.ArgumentError: unknown registry: MyAppWeb.Endpoint.Registry
    (elixir 1.19.5) lib/registry.ex:1551: Registry.info!/1
    (elixir 1.19.5) lib/registry.ex:1073: Registry.unregister_match/4
    (absinthe 1.9.0) lib/absinthe/subscription.ex:183: anonymous fn/4 in Absinthe.Subscription.unsubscribe/2
    ...
    (absinthe_plug 1.5.9) lib/absinthe/plug.ex:399: Absinthe.Plug.subscribe_loop/3
```

## Fix

Guard against the missing registry using `Process.whereis/1` in `unsubscribe/2`, following the same pattern already used in `extract_pubsub/2`.

The process dictionary cleanup (`pdict_delete_fields`) always runs regardless, so there's no resource leak.