### PR TITLE
feat: add DigitAwareLanguageConventions adapter for digit-boundary roundtrip

### DIFF
--- a/lib/absinthe/adapter.ex
+++ b/lib/absinthe/adapter.ex
@@ -8,7 +8,7 @@ defmodule Absinthe.Adapter do
   Adapters aren't a part of GraphQL, but a utility that Absinthe adds so that
   both client and server can use use conventions most natural to them.
 
-  Absinthe ships with four adapters:
+  Absinthe ships with five adapters:
 
   * `Absinthe.Adapter.LanguageConventions`, which expects schemas to be defined
     in `snake_case` (the standard Elixir convention), translating to/from `camelCase`
@@ -24,6 +24,9 @@ defmodule Absinthe.Adapter do
   * `Absinthe.Adapter.StrictLanguageConventions`, which expects schemas to be
     defined in `snake_case`, translating to `camelCase` for outgoing results.
     This adapter requires incoming query documents to use `camelCase`.
+  * `Absinthe.Adapter.DigitAwareLanguageConventions`, which extends the behavior
+    of `Absinthe.Adapter.LanguageConventions` with correct roundtrip handling of
+    field names containing digits (e.g., `requires_2fa`, `address_line_1`).
 
   To set an adapter, you pass a configuration option at runtime:
 

--- a/lib/absinthe/adapter/digit_aware_language_conventions.ex
+++ b/lib/absinthe/adapter/digit_aware_language_conventions.ex
@@ -1,0 +1,88 @@
+defmodule Absinthe.Adapter.DigitAwareLanguageConventions do
+  use Absinthe.Adapter
+  alias Absinthe.Utils
+
+  @moduledoc """
+  An adapter that extends the behavior of `Absinthe.Adapter.LanguageConventions`
+  with correct roundtrip handling of field names containing digits.
+
+  ## The problem with `LanguageConventions`
+
+  `Macro.underscore/1` does not insert underscores at letter-to-digit boundaries.
+  This means that names like `requires_2fa` get camelized to `"requires2fa"`, but
+  converting back with `Macro.underscore/1` returns `"requires2fa"` instead of
+  `"requires_2fa"` - the roundtrip breaks and the field becomes unreachable.
+
+  ## How this adapter works
+
+  - `to_external_name/2` behaves identically to `LanguageConventions` (camelCase output).
+  - `to_internal_name/2` applies `Macro.underscore/1` and then inserts underscores
+    at letter-to-digit boundaries. This ensures that names like `"requires2fa"`
+    correctly resolve to `"requires_2fa"`.
+
+  ## Examples
+
+      iex> alias Absinthe.Adapter.DigitAwareLanguageConventions, as: Adapter
+      iex> Adapter.to_internal_name("requires2fa", :field)
+      "requires_2fa"
+      iex> Adapter.to_internal_name("workPhone2", :field)
+      "work_phone_2"
+      iex> Adapter.to_internal_name("field2Name", :field)
+      "field_2_name"
+      iex> Adapter.to_internal_name("addressLine1", :field)
+      "address_line_1"
+
+  ## When to use this adapter
+
+  Use this adapter instead of `LanguageConventions` if your schema includes fields
+  with digits preceded by underscores (e.g., `:requires_2fa`, `:address_line_1`).
+
+  Note that this adapter always inserts underscores at letter-to-digit boundaries
+  during `to_internal_name/2`. If your schema includes field names where a digit
+  is part of the word without a preceding underscore (e.g., `:req1` rather than
+  `:req_1`), those names will not resolve correctly with this adapter. In that case,
+  use `LanguageConventions` instead.
+  """
+
+  @doc "Converts a camelCase name to snake_case, handling letter-to-digit boundaries"
+  @impl Absinthe.Adapter
+  def to_internal_name(nil, _role) do
+    nil
+  end
+
+  def to_internal_name("__" <> camelized_name, role) do
+    "__" <> to_internal_name(camelized_name, role)
+  end
+
+  def to_internal_name(camelized_name, _role) when is_binary(camelized_name) do
+    camelized_name
+    |> Macro.underscore()
+    |> insert_digit_underscores()
+  end
+
+  @doc "Converts a snake_case name to camelCase"
+  @impl Absinthe.Adapter
+  def to_external_name(nil, _role) do
+    nil
+  end
+
+  def to_external_name("__" <> underscored_name, role) do
+    "__" <> to_external_name(underscored_name, role)
+  end
+
+  def to_external_name(<<c::utf8, _::binary>> = name, _) when c in ?A..?Z do
+    name |> Utils.camelize()
+  end
+
+  def to_external_name(underscored_name, _role) when is_binary(underscored_name) do
+    underscored_name
+    |> Utils.camelize(lower: true)
+  end
+
+  # Insert underscores between a lowercase letter and a digit.
+  # "requires2fa" -> "requires_2fa"
+  # "work_phone2" -> "work_phone_2"
+  defp insert_digit_underscores(name) do
+    String.replace(name, ~r/([a-z])(\d)/, "\\1_\\2")
+  end
+end

--- a/test/absinthe/adapters/digit_aware_language_conventions_test.exs
+++ b/test/absinthe/adapters/digit_aware_language_conventions_test.exs
@@ -1,0 +1,107 @@
+defmodule Absinthe.Adapter.DigitAwareLanguageConventionsTest do
+  use Absinthe.Case, async: true
+
+  alias Absinthe.Adapter.DigitAwareLanguageConventions, as: Adapter
+
+  describe "to_internal_name/2" do
+    test "converts external camelcase field names to underscore" do
+      assert "foo_bar" = Adapter.to_internal_name("fooBar", :field)
+    end
+
+    test "converts external camelcase variable names to underscore" do
+      assert "foo_bar" = Adapter.to_internal_name("fooBar", :variable)
+    end
+
+    test "converts external camelcase directive names to underscore" do
+      assert "foo_bar" = Adapter.to_internal_name("fooBar", :directive)
+    end
+
+    test "handles nil" do
+      assert is_nil(Adapter.to_internal_name(nil, :field))
+    end
+
+    test "preserves __ prefix (introspection names)" do
+      assert "__type_name" = Adapter.to_internal_name("__typeName", :field)
+    end
+
+    test "handles digit boundaries in camelCase names" do
+      assert "requires_2fa" = Adapter.to_internal_name("requires2fa", :field)
+      assert "work_phone_2" = Adapter.to_internal_name("workPhone2", :field)
+      assert "field_2_name" = Adapter.to_internal_name("field2Name", :field)
+      assert "address_line_1" = Adapter.to_internal_name("addressLine1", :field)
+    end
+
+    test "inserts underscores at digit boundaries even for non-camelCase names" do
+      assert "req_1" = Adapter.to_internal_name("req1", :field)
+      assert "test_123" = Adapter.to_internal_name("test123", :field)
+    end
+
+    test "passes through already-underscored names" do
+      assert "foo_bar" = Adapter.to_internal_name("foo_bar", :field)
+      assert "requires_2fa" = Adapter.to_internal_name("requires_2fa", :field)
+    end
+  end
+
+  describe "to_external_name/2" do
+    test "converts internal underscored field names to camelcase" do
+      assert "fooBar" = Adapter.to_external_name("foo_bar", :field)
+    end
+
+    test "converts internal underscored variable names to camelcase" do
+      assert "fooBar" = Adapter.to_external_name("foo_bar", :variable)
+    end
+
+    test "handles nil" do
+      assert is_nil(Adapter.to_external_name(nil, :field))
+    end
+
+    test "preserves __ prefix (introspection names)" do
+      assert "__typeName" = Adapter.to_external_name("__type_name", :field)
+    end
+
+    test "camelizes names with digits" do
+      assert "requires2fa" = Adapter.to_external_name("requires_2fa", :field)
+      assert "workPhone2" = Adapter.to_external_name("work_phone_2", :field)
+      assert "field2Name" = Adapter.to_external_name("field_2_name", :field)
+      assert "addressLine1" = Adapter.to_external_name("address_line_1", :field)
+    end
+  end
+
+  describe "roundtrip" do
+    test "to_external then to_internal returns the original name" do
+      names = [
+        "foo_bar",
+        "requires_2fa",
+        "work_phone_2",
+        "field_2_name",
+        "address_line_1",
+        "first_name",
+        "created_at"
+      ]
+
+      for name <- names do
+        external = Adapter.to_external_name(name, :field)
+        assert name == Adapter.to_internal_name(external, :field),
+               "roundtrip failed for #{name}: #{name} -> #{external} -> #{Adapter.to_internal_name(external, :field)}"
+      end
+    end
+
+    test "to_internal then to_external returns the original camelCase name" do
+      names = [
+        "fooBar",
+        "requires2fa",
+        "workPhone2",
+        "field2Name",
+        "addressLine1",
+        "firstName",
+        "createdAt"
+      ]
+
+      for name <- names do
+        internal = Adapter.to_internal_name(name, :field)
+        assert name == Adapter.to_external_name(internal, :field),
+               "roundtrip failed for #{name}: #{name} -> #{internal} -> #{Adapter.to_external_name(internal, :field)}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey! Rewrote this based on @benwilson512's feedback. Instead of modifying LanguageConventions, this adds a new opt-in adapter: `Absinthe.Adapter.DigitAwareLanguageConventions`.

## The problem

`Macro.underscore/1` doesn't insert underscores at letter-to-digit boundaries. So a field like `:requires_2fa` gets camelized to `"requires2fa"`, but converting back gives `"requires2fa"` instead of `"requires_2fa"`. The roundtrip breaks and the field becomes unreachable from GraphQL.

This affects any field with an underscore before a digit: `:work_phone_2`, `:address_line_1`, `:field_2_name`, etc.

## The fix

A new adapter that behaves identically to `LanguageConventions` for `to_external_name/2`, but after `Macro.underscore/1` in `to_internal_name/2`, inserts underscores at `[a-z][0-9]` boundaries via a single `String.replace/3` call.

```elixir
# In your Phoenix endpoint or Absinthe config:
forward "/api",
  to: Absinthe.Plug,
  init_opts: [schema: MyAppWeb.Schema, adapter: Absinthe.Adapter.DigitAwareLanguageConventions]
```

```elixir
Adapter.to_internal_name("requires2fa", :field)   #=> "requires_2fa"
Adapter.to_internal_name("workPhone2", :field)     #=> "work_phone_2"
Adapter.to_internal_name("field2Name", :field)     #=> "field_2_name"
Adapter.to_internal_name("addressLine1", :field)   #=> "address_line_1"
```

## What changed from the previous version

- No longer modifies LanguageConventions - zero breaking change risk
- New opt-in adapter that users choose explicitly
- Simpler implementation: `Macro.underscore` + one `String.replace` for digit boundaries
- Full test coverage including roundtrip verification

## Trade-off

This adapter always inserts underscores at letter-digit boundaries. If a schema has a field like `:req1` (digit without preceding underscore), this adapter would convert it to `req_1` on input, which wouldn't match. The moduledoc documents this clearly. In practice, underscore-before-digit (`:requires_2fa`) is far more common in Elixir than digit-glued-to-word (`:req1`).

We hit this originally building [Shiko](https://shiko.vet) (veterinary SaaS in Elixir) where `:requires_2fa` on the login response was completely unreachable from GraphQL.

Closes #312, closes #298, closes #367.