### PR TITLE
fix: remove unreachable inline_middleware fallback

### DIFF
--- a/lib/absinthe/phase/schema/inline_functions.ex
+++ b/lib/absinthe/phase/schema/inline_functions.ex
@@ -68,11 +68,6 @@ defmodule Absinthe.Phase.Schema.InlineFunctions do
 
             {field_ident, %{field | middleware: [middleware_shim]}}
           end
-
-        {field_ident, field} ->
-          middleware = Absinthe.Middleware.expand(schema, field.middleware, field, type)
-
-          {field_ident, %{field | middleware: middleware}}
       end)
     end)
   end


### PR DESCRIPTION
Fixes warning on elixir 1.20
```
    warning: unknown key .middleware in expression:

        field.middleware

    the given type does not have the given key:

        dynamic(not %{..., middleware: term()})

    where "field" was given the type:

        # type: dynamic(not %{..., middleware: term()})
        # from: lib/absinthe/phase/schema/inline_functions.ex
        {field_ident, field}

    type warning found at:
    │
 73 │           middleware = Absinthe.Middleware.expand(schema, field.middleware, field, type)
    │                                                                 ~~~~~~~~~~
    │
    └─ lib/absinthe/phase/schema/inline_functions.ex:73:65: Absinthe.Phase.Schema.InlineFunctions.inline_middleware/3
```