### PR TITLE
fix: do not remove comments when formatting

### DIFF
--- a/lib/absinthe/blueprint/draft.ex
+++ b/lib/absinthe/blueprint/draft.ex
@@ -6,7 +6,10 @@ end
 
 defimpl Absinthe.Blueprint.Draft, for: List do
   def convert(nodes, root) do
-    Enum.map(nodes, &Absinthe.Blueprint.Draft.convert(&1, root))
+    nodes
+    |> Enum.map(&Absinthe.Blueprint.Draft.convert(&1, root))
+    # Comments are converted to `nil` values to be ignored
+    |> Enum.reject(&is_nil/1)
   end
 end
 

--- a/lib/absinthe/blueprint/draft.ex
+++ b/lib/absinthe/blueprint/draft.ex
@@ -6,10 +6,12 @@ end
 
 defimpl Absinthe.Blueprint.Draft, for: List do
   def convert(nodes, root) do
-    nodes
-    |> Enum.map(&Absinthe.Blueprint.Draft.convert(&1, root))
-    # Comments are converted to `nil` values to be ignored
-    |> Enum.reject(&is_nil/1)
+    Enum.flat_map(nodes, fn node ->
+      case Absinthe.Blueprint.Draft.convert(node, root) do
+        nil -> []
+        converted -> [converted]
+      end
+    end)
   end
 end
 

--- a/lib/absinthe/language/comment.ex
+++ b/lib/absinthe/language/comment.ex
@@ -14,4 +14,8 @@ defmodule Absinthe.Language.Comment do
     # Comments are not part of the executable document; skip them silently.
     def convert(_comment, _doc), do: nil
   end
+
+  defimpl Inspect do
+    defdelegate inspect(term, options), to: Absinthe.Language.Render
+  end
 end

--- a/lib/absinthe/language/comment.ex
+++ b/lib/absinthe/language/comment.ex
@@ -1,0 +1,12 @@
+defmodule Absinthe.Language.Comment do
+  @moduledoc false
+
+  alias Absinthe.Language
+
+  defstruct value: nil, loc: %{line: nil}
+
+  @type t :: %__MODULE__{
+          value: nil | String.t(),
+          loc: Language.loc_t()
+        }
+end

--- a/lib/absinthe/language/comment.ex
+++ b/lib/absinthe/language/comment.ex
@@ -1,7 +1,7 @@
 defmodule Absinthe.Language.Comment do
   @moduledoc false
 
-  alias Absinthe.Language
+  alias Absinthe.{Blueprint, Language}
 
   defstruct value: nil, loc: %{line: nil}
 
@@ -9,4 +9,9 @@ defmodule Absinthe.Language.Comment do
           value: nil | String.t(),
           loc: Language.loc_t()
         }
+
+  defimpl Blueprint.Draft do
+    # Comments are not part of the executable document; skip them silently.
+    def convert(_comment, _doc), do: nil
+  end
 end

--- a/lib/absinthe/language/render.ex
+++ b/lib/absinthe/language/render.ex
@@ -19,8 +19,22 @@ defmodule Absinthe.Language.Render do
 
   defp render(bp)
 
+  defp render(%Absinthe.Language.Comment{value: value}) do
+    value
+  end
+
   defp render(%Absinthe.Language.Document{} = doc) do
-    doc.definitions |> Enum.map(&render/1) |> join([line(), line()])
+    doc.definitions
+    |> Stream.chunk_every(2, 1)
+    |> Enum.flat_map(fn
+      [def, next_def] ->
+        sep = if comment?(def) or comment?(next_def), do: [line()], else: [line(), line()]
+        [render(def) | sep]
+
+      [def] ->
+        [render(def)]
+    end)
+    |> concat()
   end
 
   defp render(%Absinthe.Language.OperationDefinition{} = op) do
@@ -461,4 +475,7 @@ defmodule Absinthe.Language.Render do
       item, acc -> concat([render(item)] ++ splitter ++ [acc])
     end)
   end
+
+  defp comment?(%Absinthe.Language.Comment{}), do: true
+  defp comment?(_), do: false
 end

--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -55,7 +55,6 @@ defmodule Absinthe.Lexer do
   #   - UnicodeBOM
   #   - WhiteSpace
   #   - LineTerminator
-  #   - Comment
   #   - Comma
   #   - Ampersand
   ignored =
@@ -63,7 +62,6 @@ defmodule Absinthe.Lexer do
       unicode_bom,
       whitespace,
       line_terminator,
-      comment,
       comma,
       ampersand
     ])
@@ -352,6 +350,7 @@ defmodule Absinthe.Lexer do
     repeat(
       choice([
         ignore(ignored),
+        post_traverse(comment, {:comment_token, []}),
         punctuator,
         block_string_value,
         string_value,
@@ -480,6 +479,11 @@ defmodule Absinthe.Lexer do
     token_atom = value |> List.to_atom()
 
     {rest, [{token_atom, line_and_column(loc, byte_offset, length(value))}], context}
+  end
+
+  defp comment_token(rest, chars, context, loc, byte_offset) do
+    value = chars |> Enum.reverse() |> List.to_string()
+    {rest, [{:comment, line_and_column(loc, byte_offset, byte_size(value)), value}], context}
   end
 
   def line_and_column({line, line_offset}, byte_offset, column_correction) do

--- a/lib/absinthe/schema/notation/sdl.ex
+++ b/lib/absinthe/schema/notation/sdl.ex
@@ -14,6 +14,8 @@ defmodule Absinthe.Schema.Notation.SDL do
       definitions =
         doc.input.definitions
         |> Enum.map(&Absinthe.Blueprint.Draft.convert(&1, doc))
+        # Comments are converted to `nil` values to be ignored
+        |> Enum.reject(&is_nil/1)
         |> Enum.map(&put_ref(&1, ref, opts))
         |> Enum.map(fn type -> %{type | module: module} end)
 

--- a/lib/absinthe/schema/notation/sdl.ex
+++ b/lib/absinthe/schema/notation/sdl.ex
@@ -12,12 +12,17 @@ defmodule Absinthe.Schema.Notation.SDL do
   def parse(sdl, module, ref, opts) do
     with {:ok, doc} <- Absinthe.Phase.Parse.run(sdl) do
       definitions =
-        doc.input.definitions
-        |> Enum.map(&Absinthe.Blueprint.Draft.convert(&1, doc))
-        # Comments are converted to `nil` values to be ignored
-        |> Enum.reject(&is_nil/1)
-        |> Enum.map(&put_ref(&1, ref, opts))
-        |> Enum.map(fn type -> %{type | module: module} end)
+        Enum.flat_map(doc.input.definitions, fn node ->
+          case Absinthe.Blueprint.Draft.convert(node, doc) do
+            # Comments are converted to `nil` values to be ignored
+            nil ->
+              []
+
+            converted ->
+              type = put_ref(converted, ref, opts)
+              [%{type | module: module}]
+          end
+        end)
 
       {:ok, definitions}
     else

--- a/src/absinthe_parser.yrl
+++ b/src/absinthe_parser.yrl
@@ -1,5 +1,6 @@
 Nonterminals
   Document
+  Comment
   Definitions Definition OperationDefinition Fragment TypeDefinition
   ObjectTypeDefinition InterfaceTypeDefinition UnionTypeDefinition
   ScalarTypeDefinition EnumTypeDefinition InputObjectTypeDefinition TypeExtensionDefinition
@@ -21,14 +22,18 @@ Terminals
   '{' '}' '(' ')' '[' ']' '!' ':' '@' '$' '=' '|' '...'
   'query' 'mutation' 'subscription' 'fragment' 'on' 'directive' 'repeatable'
   'type' 'implements' 'interface' 'union' 'scalar' 'enum' 'input' 'extend' 'schema'
-  name int_value float_value string_value block_string_value boolean_value null.
+  name int_value float_value string_value block_string_value boolean_value null comment.
 
 Rootsymbol Document.
 
 Document -> Definitions : build_ast_node('Document', #{'definitions' => '$1'}, extract_location('$1')).
 
+Comment -> comment : build_ast_node('Comment', #{'value' => extract_comment_value('$1')}, extract_location('$1')).
+
 Definitions -> Definition : ['$1'].
 Definitions -> Definition Definitions : ['$1'|'$2'].
+Definitions -> Comment : ['$1'].
+Definitions -> Comment Definitions : ['$1'|'$2'].
 
 Definition -> OperationDefinition : '$1'.
 Definition -> DescriptionDefinition OperationDefinition : put_description('$2', '$1').
@@ -79,6 +84,8 @@ SelectionSet -> '{' Selections '}' : build_ast_node('SelectionSet', #{'selection
 
 Selections -> Selection : ['$1'].
 Selections -> Selection Selections : ['$1'|'$2'].
+Selections -> Comment : ['$1'].
+Selections -> Comment Selections : ['$1'|'$2'].
 
 Selection -> Field : '$1'.
 Selection -> FragmentSpread : '$1'.
@@ -275,6 +282,8 @@ FieldDefinitionList -> FieldDefinition : ['$1'].
 FieldDefinitionList -> FieldDefinition FieldDefinitionList : ['$1'|'$2'].
 FieldDefinitionList -> DescriptionDefinition FieldDefinition : [put_description('$2', '$1')].
 FieldDefinitionList -> DescriptionDefinition FieldDefinition FieldDefinitionList : [put_description('$2', '$1')|'$3'].
+FieldDefinitionList -> Comment : ['$1'].
+FieldDefinitionList -> Comment FieldDefinitionList : ['$1'|'$2'].
 
 FieldDefinition -> Name ':' Type : build_ast_node('FieldDefinition', #{'name' => extract_binary('$1'), 'type' => '$3'}, extract_location('$1')).
 FieldDefinition -> Name ':' Type DirectivesConst : build_ast_node('FieldDefinition', #{'name' => extract_binary('$1'), 'type' => '$3', 'directives' => '$4'}, extract_location('$1')).
@@ -289,6 +298,8 @@ InputValueDefinitionList -> InputValueDefinition InputValueDefinitionList : ['$1
 
 InputValueDefinitionList -> DescriptionDefinition InputValueDefinition : [put_description('$2', '$1')].
 InputValueDefinitionList -> DescriptionDefinition InputValueDefinition InputValueDefinitionList : [put_description('$2', '$1')|'$3'].
+InputValueDefinitionList -> Comment : ['$1'].
+InputValueDefinitionList -> Comment InputValueDefinitionList : ['$1'|'$2'].
 
 InputValueDefinition -> Name ':' Type : build_ast_node('InputValueDefinition', #{'name' => extract_binary('$1'), 'type' => '$3'}, extract_location('$1')).
 InputValueDefinition -> Name ':' Type DirectivesConst : build_ast_node('InputValueDefinition', #{'name' => extract_binary('$1'), 'type' => '$3', 'directives' => '$4'}, extract_location('$1')).
@@ -339,6 +350,8 @@ EnumValueDefinitionList -> EnumValueDefinition EnumValueDefinitionList : ['$1'|'
 
 EnumValueDefinitionList -> DescriptionDefinition EnumValueDefinition : [put_description('$2', '$1')].
 EnumValueDefinitionList -> DescriptionDefinition EnumValueDefinition EnumValueDefinitionList : [put_description('$2', '$1')|'$3'].
+EnumValueDefinitionList -> Comment : ['$1'].
+EnumValueDefinitionList -> Comment EnumValueDefinitionList : ['$1'|'$2'].
 
 DirectiveDefinitionLocations -> Name : [extract_binary('$1')].
 DirectiveDefinitionLocations -> Name '|' DirectiveDefinitionLocations : [extract_binary('$1')|'$3'].
@@ -392,6 +405,9 @@ extract_child_location(_) ->
   #{'line' => nil, 'column' => nil}.
 
 % Value-level Utilities
+
+extract_comment_value({comment, _Loc, Value}) ->
+  Value.
 
 extract_atom({Value, _Loc}) ->
   Value.

--- a/test/absinthe/formatter_test.exs
+++ b/test/absinthe/formatter_test.exs
@@ -9,4 +9,24 @@ defmodule Absinthe.FormatterTest do
   test "formats a document" do
     assert Absinthe.Formatter.format(@query) == "{\n  version\n}\n"
   end
+
+  test "keeps comments" do
+    assert Absinthe.Formatter.format("""
+           # Comment before
+           query { entity {
+             # Comment within
+             id
+           }}
+           # Comment after
+           """) == """
+           # Comment before
+           query {
+             entity {
+               # Comment within
+               id
+             }
+           }
+           # Comment after
+           """
+  end
 end

--- a/test/absinthe/formatter_test.exs
+++ b/test/absinthe/formatter_test.exs
@@ -10,7 +10,7 @@ defmodule Absinthe.FormatterTest do
     assert Absinthe.Formatter.format(@query) == "{\n  version\n}\n"
   end
 
-  test "keeps comments" do
+  test "keeps single-line comments" do
     assert Absinthe.Formatter.format("""
            # Comment before
            query { entity {
@@ -27,6 +27,28 @@ defmodule Absinthe.FormatterTest do
              }
            }
            # Comment after
+           """
+  end
+
+  test "keeps multi-line comments" do
+    assert Absinthe.Formatter.format("""
+           \"\"\"
+           Query the entity
+               and its ID
+             \"\"\"
+           query { entity {
+             id
+           }}
+           """) == """
+           \"\"\"
+           Query the entity
+               and its ID
+           \"\"\"
+           query {
+             entity {
+               id
+             }
+           }
            """
   end
 end

--- a/test/absinthe/lexer_test.exs
+++ b/test/absinthe/lexer_test.exs
@@ -82,6 +82,7 @@ defmodule Absinthe.LexerTest do
   test "document with emojis" do
     assert {:ok,
             [
+              {:comment, {1, 1}, "# A comment with a 😕 emoji."},
               {:block_string_value, {2, 1}, ~c"\"\"\"\nA block quote with a 👍 emoji.\n\"\"\""},
               {:"{", {5, 1}},
               {:name, {6, 3}, ~c"foo"},


### PR DESCRIPTION
An attempt to fix #1427

Include comments when formatting using `Absinthe.Formatter`.

~~Since I'd rather not change the internal structure of documents too much, I chose to rather rely on a more hacky solution, extracting the comments without relying on the lexer or parser in the formatter, and force including them on render. Feel free to tell me if you think the solution is wrong, and I should rather go "the long way" and modify the internal structure.~~
See https://github.com/absinthe-graphql/absinthe/pull/1428#issuecomment-4259019807
