### PR TITLE
Parse uppercase ON as an operation name

### DIFF
--- a/lib/absinthe/lexer.ex
+++ b/lib/absinthe/lexer.ex
@@ -387,7 +387,6 @@ defmodule Absinthe.Lexer do
     mutation
     null
     on
-    ON
     query
     repeatable
     scalar

--- a/test/absinthe/phase/parse_test.exs
+++ b/test/absinthe/phase/parse_test.exs
@@ -173,6 +173,15 @@ defmodule Absinthe.Phase.ParseTest do
     assert {:ok, _} = run(@query)
   end
 
+  test "can parse ON as an operation name" do
+    assert {:ok,
+            %Absinthe.Language.Document{
+              definitions: [
+                %Absinthe.Language.OperationDefinition{name: "ON", operation: :query}
+              ]
+            }} = run("query ON { id }")
+  end
+
   @query """
   query QueryWithNullLiterals($name: String = null) {
     fieldWithNullLiteral(name: $name, literalNull: null) @direct(arg: null)


### PR DESCRIPTION
## Summary
- Treat uppercase `ON` as a regular GraphQL name token instead of a reserved lexer token.
- Add a parser regression test for `query ON { id }`.

## Why
GraphQL names are case-sensitive, and only the lowercase fragment-name token `on` has special grammar treatment. An operation name of `ON` should parse as a valid `Name`.

## Tests
- `docker run --rm -v /Users/james_bellenger/workspace/absinthe:/work -v absinthe-upstream-deps:/work/deps -v absinthe-upstream-build:/work/_build -w /work -e MIX_ENV=test conformer/absinthe:dev mix test test/absinthe/phase/parse_test.exs test/absinthe/lexer_test.exs`