### PR TITLE
fix: name alias lookup on input object fields and arguments

### DIFF
--- a/lib/absinthe/phase/schema.ex
+++ b/lib/absinthe/phase/schema.ex
@@ -214,7 +214,7 @@ defmodule Absinthe.Phase.Schema do
 
     arguments
     |> Map.values()
-    |> Enum.find(&match?(%{name: ^internal_name}, &1))
+    |> Enum.find(fn arg -> arg.name == internal_name or (internal_name && arg.name == name) end)
   end
 
   # Given a name, lookup a schema directive
@@ -238,7 +238,9 @@ defmodule Absinthe.Phase.Schema do
 
     fields
     |> Map.values()
-    |> Enum.find(&match?(%{name: ^internal_name}, &1))
+    |> Enum.find(fn field ->
+      field.name == internal_name or (internal_name && field.name == name)
+    end)
   end
 
   defp find_schema_field(%Type.Field{type: maybe_wrapped_type}, name, schema, adapter) do

--- a/test/absinthe/phase/schema_test.exs
+++ b/test/absinthe/phase/schema_test.exs
@@ -35,4 +35,66 @@ defmodule Absinthe.Phase.SchemaTest do
       Absinthe.Phase.Schema.run(bp, schema: IntegerInputSchema)
     end
   end
+
+  defmodule NameAliasSchema do
+    use Absinthe.Schema
+
+    input_object :string_op do
+      field :eq, :string
+      field :neq, :string, name: "notEq"
+      field :not_in, list_of(non_null(:string))
+    end
+
+    query do
+      field :ping, :string do
+        arg :filter, :string_op
+        arg :country_code, :string, name: "countryCode"
+        resolve fn _, args, _ -> {:ok, inspect(args)} end
+      end
+    end
+  end
+
+  describe "name: alias on input object fields and arguments" do
+    test "input object field with `name:` alias is accepted" do
+      {:ok, result} =
+        Absinthe.run(
+          "query Q($f: StringOp) { ping(filter: $f) }",
+          NameAliasSchema,
+          variables: %{"f" => %{"notEq" => "PL"}}
+        )
+
+      assert %{data: %{"ping" => out}} = result
+      assert out =~ ~s(neq: "PL")
+    end
+
+    test "default snake_case identifier still works via camelCase wire name" do
+      {:ok, result} =
+        Absinthe.run(
+          "query Q($f: StringOp) { ping(filter: $f) }",
+          NameAliasSchema,
+          variables: %{"f" => %{"notIn" => ["PL", "DE"]}}
+        )
+
+      assert %{data: %{"ping" => out}} = result
+      assert out =~ ~s(not_in: ["PL", "DE"])
+    end
+
+    test "argument with `name:` alias still works" do
+      {:ok, result} = Absinthe.run("{ ping(countryCode: \"PL\") }", NameAliasSchema)
+      assert %{data: %{"ping" => out}} = result
+      assert out =~ ~s(country_code: "PL")
+    end
+
+    test "genuinely unknown input field still errors" do
+      {:ok, result} =
+        Absinthe.run(
+          "query Q($f: StringOp) { ping(filter: $f) }",
+          NameAliasSchema,
+          variables: %{"f" => %{"bogusField" => "X"}}
+        )
+
+      assert %{errors: [%{message: msg}]} = result
+      assert msg =~ ~s(In field "bogusField": Unknown field)
+    end
+  end
 end


### PR DESCRIPTION
 Fixes #1126.

Fields declared with an explicit name override (e.g. `field :neq, :string, name: "notEq"`) were being rejected at query time with `Unknown field. Did you mean "notEq"?`  even when the client sent exactly the aliased name. The same issue affected arguments declared with `name: ...`