### PR TITLE
feat: Emit operation :exception telemetry event when a pipeline phase…

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -7,6 +7,12 @@ handler function to any of the following event names:
 
 - `[:absinthe, :execute, :operation, :start]` when the operation starts
 - `[:absinthe, :execute, :operation, :stop]` when the operation finishes
+- `[:absinthe, :execute, :operation, :exception]` when any phase of the document
+  pipeline raises, throws, or exits after the operation has started (for example,
+  a resolver that raises). The metadata includes `:kind`, `:reason`, and
+  `:stacktrace` in addition to the start metadata. The exception is re-raised
+  after the event is emitted, so existing error-handling code is not affected.
+  When this event fires, `:stop` is **not** emitted for the same operation.
 - `[:absinthe, :subscription, :publish, :start]` when a subscription starts
 - `[:absinthe, :subscription, :publish, :stop]` when a subscription finishes
 - `[:absinthe, :resolve, :field, :start]` when field resolution starts

--- a/lib/absinthe/phase/telemetry.ex
+++ b/lib/absinthe/phase/telemetry.ex
@@ -4,6 +4,7 @@ defmodule Absinthe.Phase.Telemetry do
   """
   @operation_start [:absinthe, :execute, :operation, :start]
   @operation_stop [:absinthe, :execute, :operation, :stop]
+  @operation_exception [:absinthe, :execute, :operation, :exception]
 
   @subscription_start [:absinthe, :subscription, :publish, :start]
   @subscription_stop [:absinthe, :subscription, :publish, :stop]
@@ -30,7 +31,12 @@ defmodule Absinthe.Phase.Telemetry do
      %{
        blueprint
        | source: blueprint.input,
-         telemetry: %{id: id, start_time_mono: start_time_mono}
+         telemetry: %{
+           id: id,
+           start_time_mono: start_time_mono,
+           span: :operation,
+           options: options
+         }
      }}
   end
 
@@ -79,4 +85,36 @@ defmodule Absinthe.Phase.Telemetry do
 
     {:ok, blueprint}
   end
+
+  @doc """
+  Emit an operation `:exception` telemetry event when a phase raises, throws, or
+  exits while an operation span is active.
+
+  This is called by `Absinthe.Pipeline` for any phase that fails after the
+  `[:execute, :operation, :start]` event has been emitted, so exceptions raised
+  anywhere in the document pipeline (for example, in a resolver) surface as a
+  `[:absinthe, :execute, :operation, :exception]` event.
+  """
+  def handle_pipeline_exception(
+        %{telemetry: %{span: :operation, id: id, options: options}} = blueprint,
+        kind,
+        reason,
+        stacktrace
+      ) do
+    :telemetry.execute(
+      @operation_exception,
+      %{},
+      %{
+        id: id,
+        telemetry_span_context: id,
+        blueprint: blueprint,
+        options: options,
+        kind: kind,
+        reason: reason,
+        stacktrace: stacktrace
+      }
+    )
+  end
+
+  def handle_pipeline_exception(_blueprint, _kind, _reason, _stacktrace), do: :ok
 end

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -408,7 +408,17 @@ defmodule Absinthe.Pipeline do
   def run_phase([phase_config | todo] = all_phases, input, done) do
     {phase, options} = phase_invocation(phase_config)
 
-    case phase.run(input, options) do
+    result =
+      try do
+        phase.run(input, options)
+      catch
+        kind, reason ->
+          stacktrace = __STACKTRACE__
+          Phase.Telemetry.handle_pipeline_exception(input, kind, reason, stacktrace)
+          :erlang.raise(kind, reason, stacktrace)
+      end
+
+    case result do
       {:record_phases, result, fun} ->
         result = fun.(result, all_phases)
         run_phase(todo, result, [phase | done])

--- a/test/absinthe/phase/telemetry_test.exs
+++ b/test/absinthe/phase/telemetry_test.exs
@@ -1,0 +1,62 @@
+defmodule Absinthe.Phase.TelemetryTest do
+  use Absinthe.Case, async: false
+
+  @operation_start [:absinthe, :execute, :operation, :start]
+  @operation_stop [:absinthe, :execute, :operation, :stop]
+  @operation_exception [:absinthe, :execute, :operation, :exception]
+
+  defmodule Schema do
+    use Absinthe.Schema
+
+    query do
+      field :ok_thing, :string do
+        resolve fn _, _, _ -> {:ok, "fine"} end
+      end
+
+      field :raising_thing, :string do
+        resolve fn _, _, _ -> raise "kaboom" end
+      end
+    end
+  end
+
+  test "emits :start and :stop on success without emitting :exception" do
+    ref =
+      :telemetry_test.attach_event_handlers(self(), [
+        @operation_start,
+        @operation_stop,
+        @operation_exception
+      ])
+
+    assert {:ok, %{data: %{"okThing" => "fine"}}} = Absinthe.run("{ okThing }", Schema)
+
+    assert_receive {@operation_start, ^ref, %{system_time: _}, %{id: id}}
+    assert_receive {@operation_stop, ^ref, %{duration: _}, %{id: ^id}}
+    refute_received {@operation_exception, ^ref, _, _}
+  end
+
+  test "emits :exception when a resolver raises anywhere in the pipeline and re-raises" do
+    ref =
+      :telemetry_test.attach_event_handlers(self(), [
+        @operation_start,
+        @operation_stop,
+        @operation_exception
+      ])
+
+    assert_raise RuntimeError, "kaboom", fn ->
+      Absinthe.run("{ raisingThing }", Schema)
+    end
+
+    assert_receive {@operation_start, ^ref, %{system_time: _}, %{id: id}}
+
+    assert_receive {@operation_exception, ^ref, %{},
+                    %{
+                      id: ^id,
+                      telemetry_span_context: ^id,
+                      kind: :error,
+                      reason: %RuntimeError{message: "kaboom"},
+                      stacktrace: _
+                    }}
+
+    refute_received {@operation_stop, ^ref, _, _}
+  end
+end


### PR DESCRIPTION
This is the follow-up to #1434, where I mentioned wanting to apply similar
exception telemetry to `Absinthe.Phase.Telemetry`.

It adds a new `[:absinthe, :execute, :operation, :exception]` event that fires
when **any phase of the document pipeline** raises, throws, or exits after the
operation has started. The event carries `:kind`, `:reason`, and `:stacktrace` 
(in addition to the start metadata), and the exception is re-raised after the event is emitted, 
so existing error-handling behavior is unchanged.

## Design

Because a resolver raises in `Phase.Document.Execution.Resolution` — a
different phase than `Phase.Telemetry` — the catch can't live inside a single
phase. Instead:

- **Mechanism (`Absinthe.Pipeline`)**: `run_phase/3` wraps each `phase.run/2`
  in a `try/catch`. On an exception it calls
  `Phase.Telemetry.handle_pipeline_exception/4` and re-raises.
- **Policy (`Absinthe.Phase.Telemetry`)**: all telemetry logic stays here.
  The `[:execute, :operation, :start]` phase stamps a `span: :operation` marker
  (plus `options`) into `blueprint.telemetry`, and `handle_pipeline_exception/4`
  emits the event only when that marker is present.

When the exception event fires, `:stop` is not emitted for that operation
(the pipeline halts), which matches the telemetry span convention.