### PR TITLE
Reduce RAM memory usage by 60-90% in some cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-/bench
+# Track the committed benchmark suite (scripts + README) but keep any local
+# scratch output under bench/ ignored.
+/bench/*
+!/bench/*.exs
+!/bench/README.md
 /_build
 /cover
 /deps

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,62 @@
+# Memory benchmarks
+
+Benchmarks for the memory footprint of query execution, originally written for
+[#1245](https://github.com/absinthe-graphql/absinthe/issues/1245) (large list
+results using far more RAM than the response size).
+
+## Running
+
+Benchee is a `:dev`-only dependency, so run these under `MIX_ENV=dev`:
+
+```sh
+# Peak process heap (what trips :max_heap_size). Best of 3 per query.
+MIX_ENV=dev mix run bench/peak_heap.exs
+
+# Total bytes allocated per request (churn / GC pressure), via Benchee.
+MIX_ENV=dev mix run bench/memory.exs
+```
+
+Both scripts load `bench/bench_schema.exs`, which defines a small in-memory
+schema (no database, no custom types) with four queries: a large nested-object
+list (the #1245 shape), the same with a non-null element type, a flat list of
+100k strings, and a tiny control query. Query shapes and sizes live in
+`bench/bench_schema.exs` if you want to tweak them.
+
+## What they measure
+
+The two scripts measure different things, and both matter:
+
+- **`peak_heap.exs`** runs the query in a dedicated process and tracks the
+  high-water mark of its heap from `:garbage_collection` trace events. This is
+  the number behind `max_heap_size` kills — the retained peak, which Benchee's
+  allocation counter can't see.
+- **`memory.exs`** reports total bytes *allocated* over the run (churn). This
+  drives how often GC runs and CPU cost, but not the peak.
+
+"Payload" in the peak output is `byte_size(:erlang.term_to_binary(result))`, a
+rough proxy for the JSON response size (term_to_binary runs larger than JSON, so
+the reported multiples are conservative).
+
+## Reference numbers
+
+Measured locally (Elixir 1.21-dev / OTP 27), comparing `main` against the
+list-memory changes on this branch. Your absolute numbers will vary by machine;
+the ratios are the point.
+
+### Peak process heap
+
+| Query | Before | After |
+|-------|--------|-------|
+| list of 20k nested objects (#1245 repro) | 31.26 MB (34.5×) | 11.58 MB (12.8×) — **−63%** |
+| list of 20k objects, non-null elements | 26.70 MB | 9.13 MB — **−66%** |
+| list of 100k strings | 24.97 MB (16.5×) | 2.44 MB (1.6×) — **−90%** |
+| tiny query (control) | 0.02 MB | 0.02 MB |
+
+(× = multiple of payload size.)
+
+### Total allocation per request
+
+| Query | Before | After |
+|-------|--------|-------|
+| list of 20k nested objects | 77.34 MB | 64.49 MB — **−17%** |
+| list of 100k strings | 44.07 MB | 1.61 MB — **−96%** |

--- a/bench/bench_schema.exs
+++ b/bench/bench_schema.exs
@@ -1,0 +1,100 @@
+# Shared schema + data generator for the memory benchmarks (issue #1245).
+#
+# Loaded via `Code.require_file/1` from the runner scripts (bench/peak_heap.exs,
+# bench/memory.exs). Uses only built-in scalars, so it has no dependency on
+# :decimal / custom types.
+
+defmodule Absinthe.Bench.Data do
+  @moduledoc false
+
+  # Reproduces the shape from https://github.com/IvanIvanoff/absinthe_memory:
+  # `points` timeseries entries, each with `assets` nested {asset, value} rows.
+  # Defaults match the issue: 200 x 100 = 20k objects, ~40k scalar leaves.
+  def nested_objects(points \\ 200, assets \\ 100) do
+    asset_names = for i <- 1..assets, do: "asset_" <> Integer.to_string(i)
+
+    for i <- 1..points do
+      data =
+        for name <- asset_names do
+          %{asset: name, value: i * 1.0 + byte_size(name)}
+        end
+
+      %{datetime: "2026-01-01T00:#{rem(i, 60)}:00Z", data: data}
+    end
+  end
+
+  def strings(n \\ 100_000) do
+    for i <- 1..n, do: "value_" <> Integer.to_string(i)
+  end
+end
+
+defmodule Absinthe.Bench.Schema do
+  @moduledoc false
+  use Absinthe.Schema
+
+  @nested Absinthe.Bench.Data.nested_objects()
+  @strings Absinthe.Bench.Data.strings()
+
+  object :asset_data do
+    field(:asset, :string)
+    field(:value, :float)
+  end
+
+  object :timeseries_point do
+    field(:datetime, :string)
+    field(:data, list_of(:asset_data))
+  end
+
+  object :metric do
+    field :timeseries_data_per_asset, list_of(:timeseries_point) do
+      resolve(fn _, _, _ -> {:ok, @nested} end)
+    end
+  end
+
+  # Same shape but with a non-null element type, to exercise the [T!] path.
+  object :non_null_metric do
+    field :timeseries_data_per_asset, list_of(non_null(:timeseries_point)) do
+      resolve(fn _, _, _ -> {:ok, @nested} end)
+    end
+  end
+
+  query do
+    # A big list of nested objects (200 x 100 = 20k objects, ~40k scalar fields).
+    # This is the issue #1245 reproduction.
+    field :object_list, :metric do
+      resolve(fn _, _, _ -> {:ok, %{}} end)
+    end
+
+    # Same, but the list has a non-null element type ([T!]).
+    field :non_null_object_list, :non_null_metric do
+      resolve(fn _, _, _ -> {:ok, %{}} end)
+    end
+
+    # A flat list of 100k scalars.
+    field :string_list, list_of(:string) do
+      resolve(fn _, _, _ -> {:ok, @strings} end)
+    end
+
+    # A tiny, non-list query — a control to catch any CPU/allocation regression
+    # on the common small-response case.
+    field :sentinel, :string do
+      resolve(fn _, _, _ -> {:ok, "ok"} end)
+    end
+  end
+end
+
+defmodule Absinthe.Bench.Queries do
+  @moduledoc false
+
+  # {label, query} pairs shared by both runner scripts.
+  def all() do
+    [
+      {"list of 20k nested objects (#1245 repro)",
+       "{ objectList { timeseriesDataPerAsset { datetime data { asset value } } } }"},
+      {"list of 20k objects, non-null elements",
+       "{ nonNullObjectList { timeseriesDataPerAsset { datetime data { asset value } } } }"},
+      {"list of 100k strings", "{ stringList }"},
+      {"tiny query (control)", "{ sentinel }"}
+    ]
+  end
+end

--- a/bench/memory.exs
+++ b/bench/memory.exs
@@ -1,0 +1,24 @@
+# Total allocation (churn) per query via Benchee's memory measurement.
+#
+#   MIX_ENV=dev mix run bench/memory.exs
+#
+# Benchee's `memory_time` reports bytes ALLOCATED over the run (churn / GC
+# pressure), which is distinct from the retained peak measured by peak_heap.exs.
+# Both matter: churn drives how often GC runs; peak drives max_heap_size kills.
+
+Code.require_file("bench_schema.exs", __DIR__)
+
+schema = Absinthe.Bench.Schema
+
+jobs =
+  for {label, query} <- Absinthe.Bench.Queries.all(), into: %{} do
+    {label, fn -> Absinthe.run(query, schema) end}
+  end
+
+Benchee.run(
+  jobs,
+  time: 3,
+  memory_time: 2,
+  warmup: 1,
+  print: [fast_warning: false]
+)

--- a/bench/peak_heap.exs
+++ b/bench/peak_heap.exs
@@ -1,0 +1,110 @@
+# Measures the TRUE peak process heap while running a query through Absinthe.
+#
+#   MIX_ENV=dev mix run bench/peak_heap.exs
+#
+# Peak is captured from `:garbage_collection` trace events on a dedicated worker
+# process: GC fires when the heap fills, so the pre-GC block sizes are a faithful
+# high-water mark that Benchee's allocation counter cannot see. Result term size
+# (via term_to_binary) is reported as a proxy for the eventual JSON response size,
+# so we can express peak as a multiple of payload.
+
+Code.require_file("bench_schema.exs", __DIR__)
+
+defmodule Absinthe.Bench.PeakHeap do
+  @moduledoc false
+
+  @wordsize :erlang.system_info(:wordsize)
+
+  def measure(query, schema) do
+    parent = self()
+
+    worker =
+      spawn(fn ->
+        receive do
+          :go -> :ok
+        end
+
+        {:ok, result} = Absinthe.run(query, schema)
+        send(parent, {:result, byte_size(:erlang.term_to_binary(result))})
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    :erlang.trace(worker, true, [:garbage_collection, {:tracer, self()}])
+    send(worker, :go)
+
+    peak_words = collect(worker, 0)
+
+    result_bytes =
+      receive do
+        {:result, bytes} -> bytes
+      after
+        60_000 -> raise "worker timed out"
+      end
+
+    send(worker, :stop)
+    :erlang.trace(worker, false, [:garbage_collection])
+
+    %{peak_bytes: peak_words * @wordsize, result_bytes: result_bytes}
+  end
+
+  # Track the max of (young heap block + old heap block + heap fragments), in
+  # words, across every GC start/end event until the worker reports its result.
+  defp collect(worker, max) do
+    receive do
+      {:trace, ^worker, gc, info}
+      when gc in [:gc_minor_start, :gc_minor_end, :gc_major_start, :gc_major_end] ->
+        total =
+          Keyword.get(info, :heap_block_size, 0) +
+            Keyword.get(info, :old_heap_block_size, 0) +
+            Keyword.get(info, :mbuf_size, 0)
+
+        collect(worker, Kernel.max(max, total))
+    after
+      0 ->
+        # Drain done for now; block briefly for more, but bail once the result
+        # is in flight (the worker only sends :result after Absinthe.run returns).
+        receive do
+          {:trace, ^worker, gc, info}
+          when gc in [:gc_minor_start, :gc_minor_end, :gc_major_start, :gc_major_end] ->
+            total =
+              Keyword.get(info, :heap_block_size, 0) +
+                Keyword.get(info, :old_heap_block_size, 0) +
+                Keyword.get(info, :mbuf_size, 0)
+
+            collect(worker, Kernel.max(max, total))
+        after
+          200 -> max
+        end
+    end
+  end
+
+  def mb(bytes), do: Float.round(bytes / 1024 / 1024, 2)
+
+  def run_all() do
+    schema = Absinthe.Bench.Schema
+
+    IO.puts("\n=== Peak process heap (worker), best of 3 ===\n")
+
+    Enum.each(Absinthe.Bench.Queries.all(), fn {label, query} ->
+      # Best-of-3: take the max peak (worst case) and min is noise; report max.
+      runs = for _ <- 1..3, do: measure(query, schema)
+      peak = runs |> Enum.map(& &1.peak_bytes) |> Enum.max()
+      result = hd(runs).result_bytes
+      ratio = if result > 0, do: Float.round(peak / result, 1), else: 0.0
+
+      IO.puts(
+        String.pad_trailing(label, 42) <>
+          "peak=" <> String.pad_leading("#{mb(peak)} MB", 10) <>
+          "  payload=" <> String.pad_leading("#{mb(result)} MB", 9) <>
+          "  ratio=" <> "#{ratio}x"
+      )
+    end)
+
+    IO.puts("")
+  end
+end
+
+Absinthe.Bench.PeakHeap.run_all()

--- a/lib/absinthe/blueprint/execution.ex
+++ b/lib/absinthe/blueprint/execution.ex
@@ -53,6 +53,7 @@ defmodule Absinthe.Blueprint.Execution do
   @type node_t ::
           Result.Object
           | Result.List
+          | Result.LeafList
           | Result.Leaf
 
   def get(%{execution: %{result: nil} = exec} = bp_root, operation) do

--- a/lib/absinthe/blueprint/result/leaf_list.ex
+++ b/lib/absinthe/blueprint/result/leaf_list.ex
@@ -1,13 +1,11 @@
 defmodule Absinthe.Blueprint.Result.LeafList do
   @moduledoc false
 
-  # A list whose elements are leaf values (scalars or enums) with nullable
-  # element type. Because such elements never run middleware and can never be
-  # errored or null-trimmed individually, the whole list is held as one node of
-  # raw values instead of wrapping each element in a `Result.Leaf`. Serialization
-  # happens in bulk in `Absinthe.Phase.Document.Result`. Lists with a non-null
-  # element type keep the per-element `Result.Leaf` representation so the
-  # null-propagation machinery is unchanged.
+  # Holds a list of nullable scalar or enum values as a single node, rather than
+  # one `Result.Leaf` per element. That's safe because these elements never run
+  # middleware and can't be null-trimmed on their own. Lists with non-null
+  # elements keep the per-element form. The values are serialized in bulk by
+  # `Absinthe.Phase.Document.Result`.
 
   alias Absinthe.{Blueprint, Phase}
 

--- a/lib/absinthe/blueprint/result/leaf_list.ex
+++ b/lib/absinthe/blueprint/result/leaf_list.ex
@@ -1,0 +1,30 @@
+defmodule Absinthe.Blueprint.Result.LeafList do
+  @moduledoc false
+
+  # A list whose elements are leaf values (scalars or enums) with nullable
+  # element type. Because such elements never run middleware and can never be
+  # errored or null-trimmed individually, the whole list is held as one node of
+  # raw values instead of wrapping each element in a `Result.Leaf`. Serialization
+  # happens in bulk in `Absinthe.Phase.Document.Result`. Lists with a non-null
+  # element type keep the per-element `Result.Leaf` representation so the
+  # null-propagation machinery is unchanged.
+
+  alias Absinthe.{Blueprint, Phase}
+
+  @enforce_keys [:emitter]
+  defstruct [
+    :emitter,
+    values: [],
+    errors: [],
+    flags: %{},
+    extensions: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          emitter: Blueprint.Document.Field.t(),
+          values: [Blueprint.Execution.node_t()],
+          errors: [Phase.Error.t()],
+          flags: Blueprint.flags_t(),
+          extensions: %{any => any}
+        }
+end

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -99,6 +99,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     {result, res}
   end
 
+  # Compact scalar/enum list: its raw values have no fields to resolve.
+  def walk_result(%Result.LeafList{} = result, _, _, res, _) do
+    {result, res}
+  end
+
   def walk_result(%{values: values} = result, bp_node, schema_type, res, path) do
     {values, res} = walk_results(values, bp_node, schema_type, res, [0 | path], [])
     {%{result | values: values}, res}
@@ -351,6 +356,12 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp contains_non_null?(%Type.List{of_type: inner}), do: contains_non_null?(inner)
   defp contains_non_null?(_), do: false
 
+  # A compact leaf list has nullable elements and no per-element nodes, so there
+  # is nothing to trim.
+  defp propagate_null_trimming({%Result.LeafList{} = node, res}) do
+    {node, res}
+  end
+
   defp propagate_null_trimming({%{values: values} = node, res}) do
     values = Enum.map(values, &do_propagate_null_trimming/1)
     node = %{node | values: values}
@@ -380,6 +391,12 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   defp find_bad_child(%{fields: fields}) do
     Enum.find(fields, &non_null_violation?/1)
+  end
+
+  # Compact leaf lists are only built for nullable element types, so no element
+  # can be a non-null violation.
+  defp find_bad_child(%Result.LeafList{}) do
+    false
   end
 
   defp find_bad_child(%{values: values}) do
@@ -480,6 +497,20 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   defp to_result(root_value, blueprint, %Type.Union{}, extensions) do
     %Result.Object{root_value: root_value, emitter: blueprint, extensions: extensions}
+  end
+
+  # Nullable list of leaf values (scalars/enums): elements never run middleware
+  # and can't be individually errored or null-trimmed, so hold the raw values in
+  # a single compact node instead of a Result.Leaf per element. Serialized in
+  # bulk by Phase.Document.Result. A non-null element type (%Type.List{of_type:
+  # %Type.NonNull{}}) does not match these clauses and keeps the per-element path
+  # below, preserving null propagation.
+  defp to_result(root_value, blueprint, %Type.List{of_type: %Type.Scalar{}}, extensions) do
+    %Result.LeafList{values: List.wrap(root_value), emitter: blueprint, extensions: extensions}
+  end
+
+  defp to_result(root_value, blueprint, %Type.List{of_type: %Type.Enum{}}, extensions) do
+    %Result.LeafList{values: List.wrap(root_value), emitter: blueprint, extensions: extensions}
   end
 
   defp to_result(root_value, blueprint, %Type.List{of_type: inner_type}, extensions) do

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -99,7 +99,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     {result, res}
   end
 
-  # Compact scalar/enum list: its raw values have no fields to resolve.
+  # A leaf list is just raw values — there are no sub-fields to walk into.
   def walk_result(%Result.LeafList{} = result, _, _, res, _) do
     {result, res}
   end
@@ -116,14 +116,12 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   # walk list results
   #
-  # The element path is threaded through the explicit `path` argument, not by
-  # mutating `res.path`: every field resolver gets its path set by
-  # build_resolution_struct, and the only consumer of the accumulator's path
-  # before that point is a Union/Interface resolve_type callback, which now has
-  # the path stamped lazily in get_concrete_type. This avoids allocating a fresh
-  # Absinthe.Resolution struct per list element just to bump the path.
-  defp walk_results([value | values], bp_node, inner_type, res, [i | sub_path], acc) do
-    path = [i | sub_path]
+  # We pass each element's path along as an argument instead of writing it into
+  # `res`. Updating `res` meant building a new Resolution struct for every element
+  # just to record the path, which adds up on large lists. The only thing that
+  # actually reads the path off `res` is a Union/Interface `resolve_type`
+  # callback, so get_concrete_type sets it there, only when it's needed.
+  defp walk_results([value | values], bp_node, inner_type, res, [i | sub_path] = path, acc) do
     {result, res} = walk_result(value, bp_node, inner_type, res, path)
     walk_results(values, bp_node, inner_type, res, [i + 1 | sub_path], [result | acc])
   end
@@ -273,12 +271,10 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
       errors: errors
     } = res
 
-    # The emitter is the field's blueprint node with its schema_node type fully
-    # expanded (atom refs resolved to their type structs). It is a pure function
-    # of (field, schema), so for a list it is identical for every element — cache
-    # and share one term across them instead of rebuilding it per element. This
-    # is invisible to middleware: build_result runs after resolution, and the
-    # emitter is never written back into res.definition.
+    # Every element of a list ends up with the same emitter (the field node with
+    # its type expanded), so we build it once for the field and reuse it instead
+    # of rebuilding it for each element. It's never written back to res.definition,
+    # so middleware doesn't see any difference.
     {bp_field, res} = prepared_emitter(res)
     full_type = bp_field.schema_node.type
 
@@ -328,10 +324,10 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   defp maybe_add_non_null_error([], [_ | _] = values, %Type.List{of_type: type}, path) do
-    # Only walk the list when the element type actually carries a non-null
-    # constraint that could be violated; for a plain `[Foo]` there is nothing to
-    # check, so skip the O(n) pass entirely. When we do walk, track the index
-    # manually rather than materializing an Enum.with_index/1 tuple list.
+    # There's only something to check when the element type is non-null; a plain
+    # `[Foo]` can't have a non-null violation, so skip the walk entirely. When we
+    # do walk, we carry the index along in the recursion rather than building a
+    # tuple for every element with Enum.with_index/1.
     if contains_non_null?(type) do
       list_non_null_errors(values, type, path, 0)
     else
@@ -356,8 +352,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp contains_non_null?(%Type.List{of_type: inner}), do: contains_non_null?(inner)
   defp contains_non_null?(_), do: false
 
-  # A compact leaf list has nullable elements and no per-element nodes, so there
-  # is nothing to trim.
+  # A leaf list only holds nullable elements, so there's never anything to trim.
   defp propagate_null_trimming({%Result.LeafList{} = node, res}) do
     {node, res}
   end
@@ -391,12 +386,6 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   defp find_bad_child(%{fields: fields}) do
     Enum.find(fields, &non_null_violation?/1)
-  end
-
-  # Compact leaf lists are only built for nullable element types, so no element
-  # can be a non-null violation.
-  defp find_bad_child(%Result.LeafList{}) do
-    false
   end
 
   defp find_bad_child(%{values: values}) do
@@ -499,12 +488,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     %Result.Object{root_value: root_value, emitter: blueprint, extensions: extensions}
   end
 
-  # Nullable list of leaf values (scalars/enums): elements never run middleware
-  # and can't be individually errored or null-trimmed, so hold the raw values in
-  # a single compact node instead of a Result.Leaf per element. Serialized in
-  # bulk by Phase.Document.Result. A non-null element type (%Type.List{of_type:
-  # %Type.NonNull{}}) does not match these clauses and keeps the per-element path
-  # below, preserving null propagation.
+  # For a list of nullable scalars or enums there's nothing to resolve per element
+  # and nothing to null-trim, so we keep the raw values in a single node rather
+  # than wrapping each one in a Result.Leaf; they get serialized together later in
+  # Phase.Document.Result. Lists whose elements are non-null fall through to the
+  # regular clause below.
   defp to_result(root_value, blueprint, %Type.List{of_type: %Type.Scalar{}}, extensions) do
     %Result.LeafList{values: List.wrap(root_value), emitter: blueprint, extensions: extensions}
   end

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -110,13 +110,18 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   # walk list results
-  defp walk_results([value | values], bp_node, inner_type, res, [i | sub_path] = path, acc) do
-    {result, res} = walk_result(value, bp_node, inner_type, %{res | path: path}, path)
+  #
+  # The element path is threaded through the explicit `path` argument, not by
+  # mutating `res.path`: every field resolver gets its path set by
+  # build_resolution_struct, and the only consumer of the accumulator's path
+  # before that point is a Union/Interface resolve_type callback, which now has
+  # the path stamped lazily in get_concrete_type. This avoids allocating a fresh
+  # Absinthe.Resolution struct per list element just to bump the path.
+  defp walk_results([value | values], bp_node, inner_type, res, [i | sub_path], acc) do
+    path = [i | sub_path]
+    {result, res} = walk_result(value, bp_node, inner_type, res, path)
     walk_results(values, bp_node, inner_type, res, [i + 1 | sub_path], [result | acc])
   end
-
-  defp walk_results([], _, _, res = %{path: [_ | sub_path]}, _, acc),
-    do: {:lists.reverse(acc), %{res | path: sub_path}}
 
   defp walk_results([], _, _, res, _, acc), do: {:lists.reverse(acc), res}
 
@@ -125,7 +130,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     # that return type could be an interface or union, so let's make it concrete
     parent
     |> get_return_type
-    |> get_concrete_type(source, res)
+    |> get_concrete_type(source, res, path)
     |> case do
       nil ->
         {[], res}
@@ -157,15 +162,15 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   defp get_return_type(type), do: type
 
-  defp get_concrete_type(%Type.Union{} = parent_type, source, res) do
-    Type.Union.resolve_type(parent_type, source, res)
+  defp get_concrete_type(%Type.Union{} = parent_type, source, res, path) do
+    Type.Union.resolve_type(parent_type, source, %{res | path: path})
   end
 
-  defp get_concrete_type(%Type.Interface{} = parent_type, source, res) do
-    Type.Interface.resolve_type(parent_type, source, res)
+  defp get_concrete_type(%Type.Interface{} = parent_type, source, res, path) do
+    Type.Interface.resolve_type(parent_type, source, %{res | path: path})
   end
 
-  defp get_concrete_type(parent_type, _source, _res) do
+  defp get_concrete_type(parent_type, _source, _res, _path) do
     parent_type
   end
 
@@ -318,16 +323,33 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   defp maybe_add_non_null_error([], [_ | _] = values, %Type.List{of_type: type}, path) do
-    values
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {value, index} ->
-      maybe_add_non_null_error([], value, type, [index | path])
-    end)
+    # Only walk the list when the element type actually carries a non-null
+    # constraint that could be violated; for a plain `[Foo]` there is nothing to
+    # check, so skip the O(n) pass entirely. When we do walk, track the index
+    # manually rather than materializing an Enum.with_index/1 tuple list.
+    if contains_non_null?(type) do
+      list_non_null_errors(values, type, path, 0)
+    else
+      []
+    end
   end
 
   defp maybe_add_non_null_error(errors, _, _, _path) do
     errors
   end
+
+  defp list_non_null_errors([], _type, _path, _index), do: []
+
+  defp list_non_null_errors([value | values], type, path, index) do
+    case maybe_add_non_null_error([], value, type, [index | path]) do
+      [] -> list_non_null_errors(values, type, path, index + 1)
+      errors -> errors ++ list_non_null_errors(values, type, path, index + 1)
+    end
+  end
+
+  defp contains_non_null?(%Type.NonNull{}), do: true
+  defp contains_non_null?(%Type.List{of_type: inner}), do: contains_non_null?(inner)
+  defp contains_non_null?(_), do: false
 
   defp propagate_null_trimming({%{values: values} = node, res}) do
     values = Enum.map(values, &do_propagate_null_trimming/1)

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -259,15 +259,18 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp build_result(res, source, path) do
     %{
       value: value,
-      definition: bp_field,
       extensions: extensions,
-      schema: schema,
       errors: errors
     } = res
 
-    full_type = Type.expand(bp_field.schema_node.type, schema)
-
-    bp_field = put_in(bp_field.schema_node.type, full_type)
+    # The emitter is the field's blueprint node with its schema_node type fully
+    # expanded (atom refs resolved to their type structs). It is a pure function
+    # of (field, schema), so for a list it is identical for every element — cache
+    # and share one term across them instead of rebuilding it per element. This
+    # is invisible to middleware: build_result runs after resolution, and the
+    # emitter is never written back into res.definition.
+    {bp_field, res} = prepared_emitter(res)
+    full_type = bp_field.schema_node.type
 
     # if there are any errors, the value is always nil
     value =
@@ -283,6 +286,21 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     |> add_errors(Enum.reverse(errors), &put_result_error_value(&1, &2, bp_field, source, path))
     |> walk_result(bp_field, full_type, res, path)
     |> propagate_null_trimming
+  end
+
+  defp prepared_emitter(%{fields_cache: cache} = res) do
+    %{definition: bp_field, schema: schema, parent_type: parent_type, path: path} = res
+    key = {:emitter, Absinthe.Resolution.Projector.cache_key(path, parent_type.identifier)}
+
+    case Map.fetch(cache, key) do
+      {:ok, emitter} ->
+        {emitter, res}
+
+      :error ->
+        full_type = Type.expand(bp_field.schema_node.type, schema)
+        emitter = put_in(bp_field.schema_node.type, full_type)
+        {emitter, %{res | fields_cache: Map.put(cache, key, emitter)}}
+    end
   end
 
   defp maybe_add_non_null_error(errors, value, type, path \\ [])

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -44,9 +44,7 @@ defmodule Absinthe.Phase.Document.Result do
 
   defp data(%{errors: [_ | _] = field_errors}, errors), do: {nil, field_errors ++ errors}
 
-  # Compact list of leaf values (nullable scalar/enum elements): serialize the
-  # raw values in one pass. Equivalent to a list of Result.Leaf, without the
-  # per-element structs.
+  # A leaf list — serialize all of its raw values in one pass.
   defp data(%Blueprint.Result.LeafList{values: values, emitter: emitter}, errors) do
     serialized =
       Enum.map(values, fn

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -44,33 +44,24 @@ defmodule Absinthe.Phase.Document.Result do
 
   defp data(%{errors: [_ | _] = field_errors}, errors), do: {nil, field_errors ++ errors}
 
+  # Compact list of leaf values (nullable scalar/enum elements): serialize the
+  # raw values in one pass. Equivalent to a list of Result.Leaf, without the
+  # per-element structs.
+  defp data(%Blueprint.Result.LeafList{values: values, emitter: emitter}, errors) do
+    serialized =
+      Enum.map(values, fn
+        nil -> nil
+        value -> serialize_leaf(value, emitter)
+      end)
+
+    {serialized, errors}
+  end
+
   # Leaf
   defp data(%{value: nil}, errors), do: {nil, errors}
 
   defp data(%{value: value, emitter: emitter}, errors) do
-    value =
-      case Type.unwrap(emitter.schema_node.type) do
-        %Type.Scalar{} = schema_node ->
-          try do
-            Type.Scalar.serialize(schema_node, value)
-          rescue
-            _e in [Absinthe.SerializationError, Protocol.UndefinedError] ->
-              raise(
-                Absinthe.SerializationError,
-                """
-                Could not serialize term #{inspect(value)} as type #{schema_node.name}
-
-                When serializing the field:
-                #{emitter.parent_type.name}.#{emitter.schema_node.name} (#{emitter.schema_node.__reference__.location.file}:#{emitter.schema_node.__reference__.location.line})
-                """
-              )
-          end
-
-        %Type.Enum{} = schema_node ->
-          Type.Enum.serialize(schema_node, value)
-      end
-
-    {value, errors}
+    {serialize_leaf(value, emitter), errors}
   end
 
   # Object
@@ -78,6 +69,29 @@ defmodule Absinthe.Phase.Document.Result do
 
   # List
   defp data(%{values: values}, errors), do: list_data(values, errors)
+
+  defp serialize_leaf(value, emitter) do
+    case Type.unwrap(emitter.schema_node.type) do
+      %Type.Scalar{} = schema_node ->
+        try do
+          Type.Scalar.serialize(schema_node, value)
+        rescue
+          _e in [Absinthe.SerializationError, Protocol.UndefinedError] ->
+            raise(
+              Absinthe.SerializationError,
+              """
+              Could not serialize term #{inspect(value)} as type #{schema_node.name}
+
+              When serializing the field:
+              #{emitter.parent_type.name}.#{emitter.schema_node.name} (#{emitter.schema_node.__reference__.location.file}:#{emitter.schema_node.__reference__.location.line})
+              """
+            )
+        end
+
+      %Type.Enum{} = schema_node ->
+        Type.Enum.serialize(schema_node, value)
+    end
+  end
 
   defp list_data(fields, errors, acc \\ [])
   defp list_data([], errors, acc), do: {:lists.reverse(acc), errors}

--- a/lib/absinthe/resolution/projector.ex
+++ b/lib/absinthe/resolution/projector.ex
@@ -29,14 +29,11 @@ defmodule Absinthe.Resolution.Projector do
   end
 
   @doc """
-  Build the cache key identifying a projection (or any per-field prepared data)
-  for a given path and parent type identifier.
+  Builds the cache key for a projection at `path` under `parent_ident`.
 
-  The key deliberately drops list indices from the path (the comprehension only
-  matches field-shaped path entries, skipping bare integers), so every element
-  of a list shares one key. This is what lets projection — and the prepared
-  emitter cache in the resolution phase — be computed once per list rather than
-  once per element.
+  List indices are dropped from the path, so every element of a list maps to the
+  same key. That's what lets a projection (and the resolution phase's emitter
+  cache) be computed once for the whole list instead of once per element.
   """
   def cache_key(path, parent_ident) do
     path =

--- a/lib/absinthe/resolution/projector.ex
+++ b/lib/absinthe/resolution/projector.ex
@@ -12,12 +12,7 @@ defmodule Absinthe.Resolution.Projector do
   field merging, and other wonderful stuff like that.
   """
   def project(selections, %{identifier: parent_ident} = parent_type, path, cache, exec) do
-    path =
-      for %{parent_type: %{identifier: i}, name: name, alias: alias} <- path do
-        {i, alias || name}
-      end
-
-    key = [parent_ident | path]
+    key = cache_key(path, parent_ident)
 
     case Map.fetch(cache, key) do
       {:ok, fields} ->
@@ -31,6 +26,25 @@ defmodule Absinthe.Resolution.Projector do
 
         {fields, Map.put(cache, key, fields)}
     end
+  end
+
+  @doc """
+  Build the cache key identifying a projection (or any per-field prepared data)
+  for a given path and parent type identifier.
+
+  The key deliberately drops list indices from the path (the comprehension only
+  matches field-shaped path entries, skipping bare integers), so every element
+  of a list shares one key. This is what lets projection — and the prepared
+  emitter cache in the resolution phase — be computed once per list rather than
+  once per element.
+  """
+  def cache_key(path, parent_ident) do
+    path =
+      for %{parent_type: %{identifier: i}, name: name, alias: alias} <- path do
+        {i, alias || name}
+      end
+
+    [parent_ident | path]
   end
 
   defp response_key(%{alias: nil, name: name}), do: name


### PR DESCRIPTION
### Changes - Reduce memory footprint of large list results

Disclosure: Claude Fable helped write the code.

This PR addresses issues reported in [#1245](https://github.com/absinthe-graphql/absinthe/issues/1245).

Returning big lists used to blow up process memory way out of
proportion to the response - a ~0.9 MB payload peaking at 30+ MB of heap.
Turns out most of that wasn't the type checking itself, just avoidable duplication while building the result tree.

Three small, self-contained commits (details in each git message):
- share the fieldemitter across list elements instead of rebuilding it per element,
-  drop someper-element allocation churn
- collapse nullable scalar/enum lists into a single node instead of one struct per value.

Peak heap on the #1245 repro and a couple of variants:

| Query | Before | After |
|-------|--------|-------|
| 20k objects / 40k leaves | 31.26 MB | 11.58 MB (−63%) |
| list of 100k strings | 24.97 MB | 2.44 MB (−90%) |


No public API change — `Absinthe.run/3` output is byte-identical. The only thing
to flag: the scalar-list commit adds a new result node, `Result.LeafList`, so a
custom result phase that walks the tree needs one extra clause: https://github.com/absinthe-graphql/absinthe_phoenix/pull/111

PS: I see that bench tests are intentionally ignored.
I pushed the bench tests to my fork here: https://github.com/santiment/absinthe/commit/b1ee3c88d7a876cb4b5bf03bc116d3b29b801df1