### PR TITLE
perf: Avoid rewalking the tree for suspended fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           path: |
             priv/plts
-          key: "v1-${{ runner.os }}-\
+          key: "v2-${{ runner.os }}-\
             erlang-${{ matrix.otp }}-\
             elixir-${{ matrix.elixir }}-\
             ${{ hashFiles('mix.lock') }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,37 @@
 # Changelog
 
+## [1.12.0](https://github.com/absinthe-graphql/absinthe/compare/v1.11.0...v1.12.0) (Pending)
+
+### Features
+
+- Significantly Improved performance when using suspended fields (Dataloader,
+  Batching)
+- Significantly Improved memory usage when returnign lists of scalars
+
+
 ## [1.11.0](https://github.com/absinthe-graphql/absinthe/compare/v1.10.0...v1.11.0) (2026-06-04)
 
 
 ### Features
 
-* add description support for operations and fragments ([#1404](https://github.com/absinthe-graphql/absinthe/issues/1404)) ([c029a61](https://github.com/absinthe-graphql/absinthe/commit/c029a611640a764b687f6e3b5ce647880eff99fd))
-* PartitionSupervisor for subscription tasks ([#1416](https://github.com/absinthe-graphql/absinthe/issues/1416)) ([18665af](https://github.com/absinthe-graphql/absinthe/commit/18665af918a1f135171feec4f6b0d494ac105339))
+* add description support for operations and fragments
+  ([#1404](https://github.com/absinthe-graphql/absinthe/issues/1404))
+  ([c029a61](https://github.com/absinthe-graphql/absinthe/commit/c029a611640a764b687f6e3b5ce647880eff99fd))
+* PartitionSupervisor for subscription tasks
+  ([#1416](https://github.com/absinthe-graphql/absinthe/issues/1416))
+  ([18665af](https://github.com/absinthe-graphql/absinthe/commit/18665af918a1f135171feec4f6b0d494ac105339))
 
 
 ### Bug Fixes
 
-* elixir 1.20 redundant clause warnings ([#1441](https://github.com/absinthe-graphql/absinthe/issues/1441)) ([0fd4781](https://github.com/absinthe-graphql/absinthe/commit/0fd478115b0450cca00a3881ec756524e5c15bdc))
-* Handle missing registry in Subscription.unsubscribe/2 during shutdown ([#1411](https://github.com/absinthe-graphql/absinthe/issues/1411)) ([8f9816a](https://github.com/absinthe-graphql/absinthe/commit/8f9816a62de93462536e0479f91c35eb57d3dfc1))
-* Prevent non-executable definitions in document pipeline ([f968ddf](https://github.com/absinthe-graphql/absinthe/commit/f968ddf286d464a7d90aa66696c146b2d3ee0a1c))
+* elixir 1.20 redundant clause warnings
+  ([#1441](https://github.com/absinthe-graphql/absinthe/issues/1441))
+  ([0fd4781](https://github.com/absinthe-graphql/absinthe/commit/0fd478115b0450cca00a3881ec756524e5c15bdc))
+* Handle missing registry in Subscription.unsubscribe/2 during shutdown
+  ([#1411](https://github.com/absinthe-graphql/absinthe/issues/1411))
+  ([8f9816a](https://github.com/absinthe-graphql/absinthe/commit/8f9816a62de93462536e0479f91c35eb57d3dfc1))
+* Prevent non-executable definitions in document pipeline
+  ([f968ddf](https://github.com/absinthe-graphql/absinthe/commit/f968ddf286d464a7d90aa66696c146b2d3ee0a1c))
 
 ## [1.10.2](https://github.com/absinthe-graphql/absinthe/compare/v1.10.1...v1.10.2) (2026-05-08)
 

--- a/benchmarks/resolution_rewalk.exs
+++ b/benchmarks/resolution_rewalk.exs
@@ -1,0 +1,168 @@
+# Demonstrates the cost of re-walking the result tree when fields suspend.
+#
+# Run with:
+#
+#     mix run benchmarks/resolution_rewalk.exs
+#
+# The resolution phase re-runs once per "round" of suspension (batch, async,
+# dataloader). Each re-run walks the *entire* result tree — including subtrees
+# that fully resolved in an earlier pass — just to locate the suspended fields.
+#
+# Scenarios (per input size N):
+#
+#   * sync      — `{ items(count: N) { a b c d } }`
+#                 Everything resolves synchronously. 1 resolution pass.
+#                 This is the baseline cost of walking/building the tree once.
+#
+#   * batch_leaf — `{ items(count: N) { a b c d batched } }`
+#                 The classic N+1 pattern: every item has one batched field.
+#                 2 passes; the second pass re-walks all N items.
+#
+#   * chain_4 / chain_24 — `{ items(count: N) { a b c d } chain { next { ... } } }`
+#                 A single chain of K nested batched fields *next to* the wide
+#                 sync tree. Each chain level forces a full extra resolution
+#                 pass, so K levels = K+1 passes. The chain itself adds a
+#                 constant, trivial amount of real work (K batches of size 1),
+#                 so any time growth over `sync` is pure re-walk overhead.
+#
+# If re-walking were free, chain_24 would cost roughly sync + 24 tiny batch
+# lookups. Instead it costs roughly 25 × sync.
+
+defmodule Rewalk.Schema do
+  use Absinthe.Schema
+
+  import Absinthe.Resolution.Helpers, only: [batch: 3]
+
+  object :item do
+    field :a, :string
+    field :b, :string
+    field :c, :string
+    field :d, :string
+
+    field :batched, :string do
+      resolve fn item, _, _ ->
+        batch({__MODULE__, :lookup}, item.id, fn results ->
+          {:ok, Map.get(results, item.id)}
+        end)
+      end
+    end
+  end
+
+  object :chain_node do
+    field :depth, :integer
+
+    field :next, :chain_node do
+      resolve fn node, _, _ ->
+        batch({__MODULE__, :next_node}, node.depth, fn results ->
+          {:ok, Map.get(results, node.depth)}
+        end)
+      end
+    end
+  end
+
+  query do
+    field :items, list_of(:item) do
+      arg :count, non_null(:integer)
+
+      resolve fn _, %{count: count}, _ ->
+        items = for i <- 1..count, do: %{id: i, a: "a", b: "b", c: "c", d: "d"}
+        {:ok, items}
+      end
+    end
+
+    field :chain, :chain_node do
+      resolve fn _, _, _ -> {:ok, %{depth: 0}} end
+    end
+  end
+
+  def lookup(_, ids), do: Map.new(ids, &{&1, "batched-#{&1}"})
+
+  def next_node(_, depths), do: Map.new(depths, &{&1, %{depth: &1 + 1}})
+end
+
+defmodule Rewalk.Bench do
+  alias Absinthe.{Pipeline, Phase}
+
+  @resolution_phase Phase.Document.Execution.Resolution
+
+  def queries(count) do
+    %{
+      sync: "{ items(count: #{count}) { a b c d } }",
+      batch_leaf: "{ items(count: #{count}) { a b c d batched } }",
+      chain_4: "{ items(count: #{count}) { a b c d } chain { #{chain(4)} } }",
+      chain_24: "{ items(count: #{count}) { a b c d } chain { #{chain(24)} } }"
+    }
+  end
+
+  defp chain(0), do: "depth"
+  defp chain(k), do: "depth next { #{chain(k - 1)} }"
+
+  # Run the pipeline up to (but not including) the resolution phase, so
+  # benchmark iterations measure only resolution + result construction.
+  def prepare(query) do
+    pipeline = Pipeline.for_document(Rewalk.Schema, [])
+    {:ok, bp, _} = Pipeline.run(query, Pipeline.before(pipeline, @resolution_phase))
+    bp
+  end
+
+  def resolution_tail do
+    Rewalk.Schema
+    |> Pipeline.for_document([])
+    |> Pipeline.from(@resolution_phase)
+  end
+
+  def resolve(bp, tail) do
+    {:ok, bp, _} = Pipeline.run(bp, tail)
+    bp.result
+  end
+
+  def sanity_check! do
+    tail = resolution_tail()
+
+    for {name, query} <- queries(3) do
+      result = resolve(prepare(query), tail)
+
+      unless match?(%{data: %{}}, result) and not Map.has_key?(result, :errors) do
+        raise "sanity check failed for #{name}: #{inspect(result)}"
+      end
+    end
+
+    # Verify the chain actually resolves to full depth.
+    %{data: data} = resolve(prepare(queries(3).chain_24), tail)
+    depth = depth_of(data["chain"])
+
+    unless depth == 25 do
+      raise "expected chain depth 25, got #{depth}"
+    end
+
+    IO.puts("sanity checks passed\n")
+  end
+
+  defp depth_of(%{"next" => next}), do: 1 + depth_of(next)
+  defp depth_of(_), do: 1
+end
+
+Rewalk.Bench.sanity_check!()
+
+tail = Rewalk.Bench.resolution_tail()
+
+inputs =
+  for count <- [100, 1_000, 10_000], into: %{} do
+    prepared =
+      Map.new(Rewalk.Bench.queries(count), fn {name, q} -> {name, Rewalk.Bench.prepare(q)} end)
+
+    {"#{count} items", prepared}
+  end
+
+Benchee.run(
+  %{
+    "sync (1 pass)" => fn %{sync: bp} -> Rewalk.Bench.resolve(bp, tail) end,
+    "batch_leaf (2 passes)" => fn %{batch_leaf: bp} -> Rewalk.Bench.resolve(bp, tail) end,
+    "chain_4 (5 passes)" => fn %{chain_4: bp} -> Rewalk.Bench.resolve(bp, tail) end,
+    "chain_24 (25 passes)" => fn %{chain_24: bp} -> Rewalk.Bench.resolve(bp, tail) end
+  },
+  inputs: inputs,
+  warmup: 1,
+  time: 3,
+  memory_time: 1
+)

--- a/lib/absinthe/blueprint/execution.ex
+++ b/lib/absinthe/blueprint/execution.ex
@@ -41,19 +41,24 @@ defmodule Absinthe.Blueprint.Execution do
     result: nil,
     acc: %{},
     context: %{},
-    root_value: %{}
+    root_value: %{},
+    pending: [],
+    resolved: %{}
   ]
 
   @type t :: %__MODULE__{
           validation_errors: [Phase.Error.t()],
           result: nil | Result.Object.t(),
-          acc: acc
+          acc: acc,
+          pending: [{reference, Absinthe.Resolution.t()}],
+          resolved: %{optional(reference) => node_t}
         }
 
   @type node_t ::
           Result.Object
           | Result.List
           | Result.Leaf
+          | Result.Pending
 
   def get(%{execution: %{result: nil} = exec} = bp_root, operation) do
     result = %Result.Object{

--- a/lib/absinthe/blueprint/result/pending.ex
+++ b/lib/absinthe/blueprint/result/pending.ex
@@ -1,0 +1,28 @@
+defmodule Absinthe.Blueprint.Result.Pending do
+  @moduledoc false
+
+  # Placeholder left in the result tree where a field suspended. The suspended
+  # `%Absinthe.Resolution{}` itself is held in the `:pending` pool on
+  # `%Absinthe.Blueprint.Execution{}`, keyed by `:ref`. Once every suspended
+  # field has resolved, placeholders are replaced by their built results in a
+  # single substitution pass.
+
+  alias Absinthe.{Blueprint, Phase}
+
+  @enforce_keys [:ref, :emitter]
+  defstruct [
+    :ref,
+    :emitter,
+    errors: [],
+    flags: %{},
+    extensions: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          ref: reference,
+          emitter: Blueprint.Document.Field.t(),
+          errors: [Phase.Error.t()],
+          flags: Blueprint.flags_t(),
+          extensions: %{any => any}
+        }
+end

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -290,8 +290,8 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
          parent_type,
          path
        ) do
-    full_type = Type.expand(field.schema_node.type, res.schema)
-    emitter = put_in(field.schema_node.type, full_type)
+    {emitter, res} = prepared_emitter(res, field, parent_type, path)
+    full_type = emitter.schema_node.type
 
     case Type.unwrap(full_type) do
       %struct{} when struct in [Type.Union, Type.Interface] ->
@@ -405,15 +405,17 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp build_result(res, source, path) do
     %{
       value: value,
-      definition: bp_field,
       extensions: extensions,
-      schema: schema,
       errors: errors
     } = res
 
-    full_type = Type.expand(bp_field.schema_node.type, schema)
-
-    bp_field = put_in(bp_field.schema_node.type, full_type)
+    # Every element of a list ends up with the same emitter (the field node
+    # with its type expanded), so we build it once per field and reuse it
+    # instead of rebuilding it for each element. It's never written back to
+    # res.definition, so middleware sees no difference; result nodes carry the
+    # same emitter values as before, just shared.
+    {bp_field, res} = prepared_emitter(res, res.definition, res.parent_type, res.path)
+    full_type = bp_field.schema_node.type
 
     # if there are any errors, the value is always nil
     value =
@@ -429,6 +431,20 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     |> add_errors(Enum.reverse(errors), &put_result_error_value(&1, &2, bp_field, source, path))
     |> walk_result(bp_field, full_type, res, path)
     |> propagate_null_trimming
+  end
+
+  defp prepared_emitter(%{fields_cache: cache} = res, bp_field, parent_type, path) do
+    key = {:emitter, Absinthe.Resolution.Projector.cache_key(path, parent_type.identifier)}
+
+    case Map.fetch(cache, key) do
+      {:ok, emitter} ->
+        {emitter, res}
+
+      :error ->
+        full_type = Type.expand(bp_field.schema_node.type, res.schema)
+        emitter = put_in(bp_field.schema_node.type, full_type)
+        {emitter, %{res | fields_cache: Map.put(cache, key, emitter)}}
+    end
   end
 
   defp maybe_add_non_null_error(errors, value, type, path \\ [])

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -5,6 +5,17 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   #
   # Blueprint results are placed under `blueprint.result.execution`. This is
   # because the results form basically a new tree from the original blueprint.
+  #
+  # The first run of this phase walks the operation and builds the result tree.
+  # Fields that suspend (async, batch, dataloader) leave a
+  # `%Result.Pending{ref: ref}` placeholder in the tree; the suspended
+  # `%Absinthe.Resolution{}` structs are collected in a flat pool under
+  # `execution.pending`. Subsequent runs of this phase iterate only that pool —
+  # the already-built result tree is not re-walked. Results of resumed fields
+  # (which may themselves contain new placeholders) accumulate in
+  # `execution.resolved`, keyed by ref. Once the pool is empty, placeholders
+  # are replaced by their results in a single substitution pass that also
+  # applies non-null propagation along the substituted paths.
 
   alias Absinthe.{Blueprint, Type, Phase}
   alias Blueprint.{Result, Execution}
@@ -62,6 +73,16 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
       }
       |> Map.merge(common)
 
+    exec = do_perform_resolution(exec, operation, res)
+
+    exec = plugins |> run_callbacks(:after_resolution, exec, run_callbacks?)
+
+    maybe_substitute_pending(exec)
+  end
+
+  # First run: expand the operation into the result tree. Suspended fields
+  # leave placeholders in the tree and are collected into the pending pool.
+  defp do_perform_resolution(%{result: %{fields: nil}} = exec, operation, res) do
     {result, res} =
       exec.result
       |> walk_result(operation, operation.schema_node, res, [operation])
@@ -69,9 +90,88 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
     exec = update_persisted_fields(exec, res)
 
-    exec = plugins |> run_callbacks(:after_resolution, exec, run_callbacks?)
+    %{exec | result: result, pending: Enum.reverse(res.pending)}
+  end
 
-    %{exec | result: result}
+  # Subsequent runs: resume only the suspended fields in the pending pool. The
+  # result tree already built in previous runs is left untouched; completed
+  # results are stored by ref for the final substitution pass.
+  defp do_perform_resolution(exec, _operation, res) do
+    {pool, resolved, res} =
+      Enum.reduce(exec.pending, {[], exec.resolved, res}, &resolve_pending/2)
+
+    exec = update_persisted_fields(exec, res)
+
+    %{exec | pending: Enum.reverse(pool, Enum.reverse(res.pending)), resolved: resolved}
+  end
+
+  defp resolve_pending({ref, old_res}, {pool, resolved, res}) do
+    res = update_persisted_fields(old_res, res)
+
+    res
+    |> reduce_resolution
+    |> case do
+      %{state: :resolved} = res ->
+        {result, res} = build_result(res, res.source, res.path)
+        {pool, Map.put(resolved, ref, result), res}
+
+      %{state: :suspended} = suspended_res ->
+        pool = [{ref, %{suspended_res | pending: []}} | pool]
+        {pool, resolved, update_persisted_fields(res, suspended_res)}
+
+      final_res ->
+        raise """
+        Should have halted or suspended middleware
+        Started with: #{inspect(res)}
+        Ended with: #{inspect(final_res)}
+        """
+    end
+  end
+
+  # Once nothing remains suspended, splice the resolved results in over their
+  # placeholders. This is the only walk of the existing tree that re-running
+  # this phase performs, and it happens exactly once per document.
+  defp maybe_substitute_pending(%{pending: [], resolved: resolved} = exec)
+       when map_size(resolved) > 0 do
+    {result, _} = substitute(exec.result, resolved)
+    %{exec | result: result, resolved: %{}}
+  end
+
+  defp maybe_substitute_pending(exec), do: exec
+
+  defp substitute(%Result.Pending{ref: ref}, resolved) do
+    {node, _} = substitute(Map.fetch!(resolved, ref), resolved)
+    {node, true}
+  end
+
+  defp substitute(%Result.Object{fields: fields} = node, resolved) do
+    case substitute_all(fields, resolved) do
+      {_, false} ->
+        {node, false}
+
+      {fields, true} ->
+        {do_propagate_null_trimming(%{node | fields: fields}), true}
+    end
+  end
+
+  defp substitute(%Result.List{values: values} = node, resolved) do
+    case substitute_all(values, resolved) do
+      {_, false} ->
+        {node, false}
+
+      {values, true} ->
+        values = Enum.map(values, &do_propagate_null_trimming/1)
+        {do_propagate_null_trimming(%{node | values: values}), true}
+    end
+  end
+
+  defp substitute(node, _resolved), do: {node, false}
+
+  defp substitute_all(nodes, resolved) do
+    Enum.map_reduce(nodes, false, fn node, changed ->
+      {node, node_changed} = substitute(node, resolved)
+      {node, changed or node_changed}
+    end)
   end
 
   defp run_callbacks(plugins, callback, acc, true) do
@@ -81,18 +181,16 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   defp run_callbacks(_, _, acc, _), do: acc
 
   @doc """
-  This function walks through any existing results. If no results are found at a
-  given node, it will call the requisite function to expand and build those results
+  This function builds the results under a given node. Any suspended fields
+  encountered leave a `%Result.Pending{}` placeholder and are accumulated on
+  the resolution struct's `:pending` list.
   """
   def walk_result(%{fields: nil} = result, bp_node, _schema_type, res, path) do
     {fields, res} = resolve_fields(bp_node, res, result.root_value, path)
-    {%{result | fields: fields}, res}
-  end
-
-  def walk_result(%{fields: fields} = result, bp_node, schema_type, res, path) do
-    {fields, res} = walk_results(fields, bp_node, schema_type, res, [0 | path], [])
-
-    {%{result | fields: fields}, res}
+    # The source value is only needed to resolve this object's own fields, so
+    # release it here: otherwise every object in the tree pins its source data
+    # in memory until the whole response has been serialized.
+    {%{result | fields: fields, root_value: nil}, res}
   end
 
   def walk_result(%Result.Leaf{} = result, _, _, res, _) do
@@ -102,11 +200,6 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   def walk_result(%{values: values} = result, bp_node, schema_type, res, path) do
     {values, res} = walk_results(values, bp_node, schema_type, res, [0 | path], [])
     {%{result | values: values}, res}
-  end
-
-  def walk_result(%Absinthe.Resolution{} = old_res, _bp_node, _schema_type, res, _path) do
-    res = update_persisted_fields(old_res, res)
-    do_resolve_field(res, res.source, res.path)
   end
 
   # walk list results
@@ -170,12 +263,57 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   defp do_resolve_fields([field | fields], res, source, parent_type, path, acc) do
-    field = %{field | parent_type: parent_type}
-    {result, res} = resolve_field(field, res, source, parent_type, [field | path])
+    {result, res} = maybe_fast_resolve(field, res, source, parent_type, [field | path])
     do_resolve_fields(fields, res, source, parent_type, path, [result | acc])
   end
 
   defp do_resolve_fields([], res, _, _, _, acc), do: {:lists.reverse(acc), res}
+
+  # Fast path for the default resolver. A field whose middleware is exactly
+  # `[{MapGet, key}]` cannot error, suspend, or touch anything on the
+  # resolution struct, so building one (and copying it again inside
+  # `MapGet.call/2`) is pure overhead — we just fetch the value and build its
+  # result directly. The fast path only applies when MapGet is the field's
+  # *only* middleware; abstract return types fall through to the regular path
+  # because `resolve_type` callbacks receive the resolution struct.
+  #
+  # NOTE: We plan to generalize this into an opt-in `{:fast, {module, fun,
+  # args}}` middleware spec so that schemas which replace the default (e.g.
+  # with an Ecto-aware getter) keep the fast path. That's a user-facing
+  # feature with docs/validation/naming work attached — see
+  # FAST_MIDDLEWARE_PLAN.md for the design and a validated prototype.
+  defp maybe_fast_resolve(
+         %{schema_node: %{middleware: [{Absinthe.Middleware.MapGet, key}]}} = field,
+         res,
+         source,
+         parent_type,
+         path
+       ) do
+    full_type = Type.expand(field.schema_node.type, res.schema)
+    emitter = put_in(field.schema_node.type, full_type)
+
+    case Type.unwrap(full_type) do
+      %struct{} when struct in [Type.Union, Type.Interface] ->
+        resolve_field(field, res, source, parent_type, path)
+
+      _ ->
+        value = Map.get(source, key)
+        errors = maybe_add_non_null_error([], value, full_type)
+
+        value
+        |> to_result(emitter, full_type, res.extensions)
+        |> add_errors(
+          Enum.reverse(errors),
+          &put_result_error_value(&1, &2, emitter, source, path)
+        )
+        |> walk_result(emitter, full_type, res, path)
+        |> propagate_null_trimming
+    end
+  end
+
+  defp maybe_fast_resolve(field, res, source, parent_type, path) do
+    resolve_field(field, res, source, parent_type, path)
+  end
 
   def resolve_field(field, res, source, parent_type, path) do
     res
@@ -192,7 +330,9 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
         build_result(res, source, path)
 
       %{state: :suspended} = res ->
-        {res, res}
+        ref = make_ref()
+        placeholder = %Result.Pending{ref: ref, emitter: res.definition}
+        {placeholder, %{res | pending: [{ref, %{res | pending: []}} | res.pending]}}
 
       final_res ->
         raise """
@@ -203,8 +343,13 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     end
   end
 
-  defp update_persisted_fields(dest, %{acc: acc, context: context, fields_cache: cache}) do
-    %{dest | acc: acc, context: context, fields_cache: cache}
+  defp update_persisted_fields(dest, %{
+         acc: acc,
+         context: context,
+         fields_cache: cache,
+         pending: pending
+       }) do
+    %{dest | acc: acc, context: context, fields_cache: cache, pending: pending}
   end
 
   defp build_resolution_struct(
@@ -312,9 +457,16 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   defp propagate_null_trimming({%{values: values} = node, res}) do
-    values = Enum.map(values, &do_propagate_null_trimming/1)
-    node = %{node | values: values}
-    {do_propagate_null_trimming(node), res}
+    # Only rebuild the list when something actually needs to be trimmed; in the
+    # common all-good case this avoids re-allocating the values list (and a
+    # copy of the node) just to put back identical elements.
+    if Enum.any?(values, &needs_trimming?/1) do
+      values = Enum.map(values, &do_propagate_null_trimming/1)
+      node = %{node | values: values}
+      {do_propagate_null_trimming(node), res}
+    else
+      {node, res}
+    end
   end
 
   defp propagate_null_trimming({node, res}) do
@@ -336,6 +488,12 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     else
       node
     end
+  end
+
+  # A list element needs the trimming pass if it must be nulled out itself
+  # (a bad child of its own) or if it violates the list's element nullability.
+  defp needs_trimming?(element) do
+    find_bad_child(element) || non_null_list_violation?(element)
   end
 
   defp find_bad_child(%{fields: fields}) do

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -185,12 +185,13 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   encountered leave a `%Result.Pending{}` placeholder and are accumulated on
   the resolution struct's `:pending` list.
   """
+  # Note: `root_value` must stay on the built object even though this phase no
+  # longer needs it — downstream result phases can consume it (e.g.
+  # Absinthe.Phoenix.Controller.Result returns raw source values for objects
+  # without subselections and merges them for `@put`).
   def walk_result(%{fields: nil} = result, bp_node, _schema_type, res, path) do
     {fields, res} = resolve_fields(bp_node, res, result.root_value, path)
-    # The source value is only needed to resolve this object's own fields, so
-    # release it here: otherwise every object in the tree pins its source data
-    # in memory until the whole response has been serialized.
-    {%{result | fields: fields, root_value: nil}, res}
+    {%{result | fields: fields}, res}
   end
 
   def walk_result(%Result.Leaf{} = result, _, _, res, _) do

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -42,6 +42,18 @@ defmodule Absinthe.Phase.Document.Result do
     %{errors: errors}
   end
 
+  defp data(%Blueprint.Result.Pending{} = node, _errors) do
+    raise """
+    Found a pending field placeholder!
+
+    A field suspended but was never resumed. This can happen when a middleware
+    suspends resolution without a plugin scheduling another resolution phase,
+    or when plugin callbacks are disabled.
+
+    #{inspect(node.emitter.name)} at #{inspect(node.emitter.source_location)}
+    """
+  end
+
   defp data(%{errors: [_ | _] = field_errors}, errors), do: {nil, field_errors ++ errors}
 
   # Leaf
@@ -89,16 +101,6 @@ defmodule Absinthe.Phase.Document.Result do
 
   defp field_data(fields, errors, acc \\ [])
   defp field_data([], errors, acc), do: {Map.new(acc), errors}
-
-  defp field_data([%Absinthe.Resolution{} = res | _], _errors, _acc) do
-    raise """
-    Found unresolved resolution struct!
-
-    You probably forgot to run the resolution phase again.
-
-    #{inspect(res)}
-    """
-  end
 
   defp field_data([field | fields], errors, acc) do
     {value, errors} = data(field, errors)

--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -74,7 +74,10 @@ defmodule Absinthe.Resolution do
     path: [],
     state: :unresolved,
     fragments: [],
-    fields_cache: %{}
+    fields_cache: %{},
+    # Internal to the resolution phase: suspended fields collected during the
+    # current pass, as `{ref, %Absinthe.Resolution{}}` in reverse walk order.
+    pending: []
   ]
 
   def resolver_spec(fun) do

--- a/lib/absinthe/resolution/projector.ex
+++ b/lib/absinthe/resolution/projector.ex
@@ -12,12 +12,7 @@ defmodule Absinthe.Resolution.Projector do
   field merging, and other wonderful stuff like that.
   """
   def project(selections, %{identifier: parent_ident} = parent_type, path, cache, exec) do
-    path =
-      for %{parent_type: %{identifier: i}, name: name, alias: alias} <- path do
-        {i, alias || name}
-      end
-
-    key = [parent_ident | path]
+    key = cache_key(path, parent_ident)
 
     case Map.fetch(cache, key) do
       {:ok, fields} ->
@@ -31,6 +26,22 @@ defmodule Absinthe.Resolution.Projector do
 
         {fields, Map.put(cache, key, fields)}
     end
+  end
+
+  @doc """
+  Builds the cache key for a projection at `path` under `parent_ident`.
+
+  List indices are dropped from the path, so every element of a list maps to the
+  same key. That's what lets a projection (and the resolution phase's emitter
+  cache) be computed once for the whole list instead of once per element.
+  """
+  def cache_key(path, parent_ident) do
+    path =
+      for %{parent_type: %{identifier: i}, name: name, alias: alias} <- path do
+        {i, alias || name}
+      end
+
+    [parent_ident | path]
   end
 
   defp response_key(%{alias: nil, name: name}), do: name

--- a/lib/absinthe/resolution/projector.ex
+++ b/lib/absinthe/resolution/projector.ex
@@ -125,15 +125,19 @@ defmodule Absinthe.Resolution.Projector do
     end
   end
 
-  # necessary when the field in question is on an abstract type.
-  defp update_schema_node(%{name: "__" <> _} = field, _) do
-    field
+  # necessary when the field in question is on an abstract type. We also record
+  # the concrete parent type on the field here: the projection is cached per
+  # parent type, so this happens once per (type, path) instead of copying the
+  # field struct again for every element during resolution.
+  defp update_schema_node(%{name: "__" <> _} = field, parent_type) do
+    %{field | parent_type: parent_type}
   end
 
-  defp update_schema_node(%{schema_node: %{identifier: identifier}} = field, %{
-         fields: concrete_fields
-       }) do
-    %{field | schema_node: :maps.get(identifier, concrete_fields)}
+  defp update_schema_node(
+         %{schema_node: %{identifier: identifier}} = field,
+         %{fields: concrete_fields} = parent_type
+       ) do
+    %{field | schema_node: :maps.get(identifier, concrete_fields), parent_type: parent_type}
   end
 
   defp normalize_condition(%{schema_node: condition}, schema) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Absinthe.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/absinthe-graphql/absinthe"
-  @version "1.11.0"
+  @version "1.12.0"
 
   def project do
     [

--- a/test/absinthe/middleware/batch_test.exs
+++ b/test/absinthe/middleware/batch_test.exs
@@ -243,7 +243,7 @@ defmodule Absinthe.Middleware.BatchTest do
                      %{id: start_id, batch_fun: {RaisingModule, :boom}}, _}}
 
     assert_receive {:telemetry_event,
-                    {[:absinthe, :middleware, :batch, :exception], %{duration: duration},
+                    {[:absinthe, :middleware, :batch, :exception], %{duration: _duration},
                      %{
                        id: stop_id,
                        batch_fun: {RaisingModule, :boom},
@@ -251,7 +251,7 @@ defmodule Absinthe.Middleware.BatchTest do
                        batch_data: _,
                        kind: :error,
                        reason: %RuntimeError{message: "kaboom"},
-                       stacktrace: stacktrace
+                       stacktrace: _stacktrace
                      }, _}}
 
     assert start_id == stop_id

--- a/test/absinthe/phase/execution/non_null_suspended_test.exs
+++ b/test/absinthe/phase/execution/non_null_suspended_test.exs
@@ -1,0 +1,261 @@
+defmodule Absinthe.Phase.Execution.NonNullSuspendedTest do
+  # Non-null propagation must behave identically whether a field resolves
+  # synchronously or suspends (batch/async) and resolves in a later resolution
+  # pass. These tests run the same document in each mode and require identical
+  # results.
+
+  use Absinthe.Case, async: true
+
+  defmodule Schema do
+    use Absinthe.Schema
+
+    import Absinthe.Resolution.Helpers, only: [batch: 3, async: 1]
+
+    enum :mode do
+      value :sync
+      value :batch
+      value :async
+    end
+
+    object :thing do
+      field :name, non_null(:string), resolve: &__MODULE__.resolve_name/3
+      field :nullable_name, :string, resolve: &__MODULE__.resolve_name/3
+
+      # Nullable scalar list.
+      field :tags, list_of(:string), resolve: &__MODULE__.resolve_tags/3
+
+      # Non-null elements: keeps the per-element form and must null out the
+      # whole list when an element is nil.
+      field :strict_tags, list_of(non_null(:string)), resolve: &__MODULE__.resolve_tags/3
+    end
+
+    object :inner do
+      field :thing, non_null(:thing) do
+        resolve fn %{mode: mode}, _, _ -> {:ok, %{id: :nil_thing, mode: mode}} end
+      end
+    end
+
+    object :chain do
+      field :child, non_null(:thing) do
+        resolve fn
+          %{mode: :sync}, _, _ ->
+            {:ok, %{id: :nil_thing, mode: :sync}}
+
+          %{mode: :batch}, _, _ ->
+            batch({__MODULE__, :children}, :batch, fn _ ->
+              {:ok, %{id: :nil_thing, mode: :batch}}
+            end)
+
+          %{mode: :async}, _, _ ->
+            async(fn -> {:ok, %{id: :nil_thing, mode: :async}} end)
+        end
+      end
+    end
+
+    query do
+      field :thing, :thing do
+        arg :mode, non_null(:mode)
+        resolve fn _, %{mode: mode}, _ -> {:ok, %{id: :nil_thing, mode: mode}} end
+      end
+
+      field :deep, :inner do
+        arg :mode, non_null(:mode)
+        resolve fn _, %{mode: mode}, _ -> {:ok, %{mode: mode}} end
+      end
+
+      field :things, list_of(non_null(:thing)) do
+        arg :mode, non_null(:mode)
+
+        resolve fn _, %{mode: mode}, _ ->
+          {:ok, [%{id: 1, mode: mode}, %{id: :nil_thing, mode: mode}]}
+        end
+      end
+
+      field :ok_things, list_of(non_null(:thing)) do
+        arg :mode, non_null(:mode)
+
+        resolve fn _, %{mode: mode}, _ ->
+          {:ok, [%{id: 1, mode: mode}, %{id: 2, mode: mode}]}
+        end
+      end
+
+      field :chain, :chain do
+        arg :mode, non_null(:mode)
+        resolve fn _, %{mode: mode}, _ -> {:ok, %{mode: mode}} end
+      end
+    end
+
+    def resolve_name(%{id: id, mode: :sync}, _, _) do
+      {:ok, name_for(id)}
+    end
+
+    def resolve_name(%{id: id, mode: :batch}, _, _) do
+      batch({__MODULE__, :names}, id, fn results ->
+        {:ok, Map.get(results, id)}
+      end)
+    end
+
+    def resolve_name(%{id: id, mode: :async}, _, _) do
+      async(fn -> {:ok, name_for(id)} end)
+    end
+
+    def resolve_tags(%{id: id, mode: :sync}, _, _) do
+      {:ok, tags_for(id)}
+    end
+
+    def resolve_tags(%{id: id, mode: :batch}, _, _) do
+      batch({__MODULE__, :tags}, id, fn results ->
+        {:ok, Map.get(results, id)}
+      end)
+    end
+
+    def resolve_tags(%{id: id, mode: :async}, _, _) do
+      async(fn -> {:ok, tags_for(id)} end)
+    end
+
+    def names(_, ids), do: Map.new(ids, &{&1, name_for(&1)})
+
+    def tags(_, ids), do: Map.new(ids, &{&1, tags_for(&1)})
+
+    defp tags_for(id), do: ["a-#{id}", nil, "b-#{id}"]
+
+    def children(_, _), do: %{}
+
+    defp name_for(:nil_thing), do: nil
+    defp name_for(id), do: "thing-#{id}"
+  end
+
+  defp assert_all_modes_agree(query, expected_data) do
+    results =
+      for mode <- ~w(SYNC BATCH ASYNC) do
+        {mode, Absinthe.run!(query, Schema, variables: %{"mode" => mode})}
+      end
+
+    for {mode, result} <- results do
+      assert result.data == expected_data, "data mismatch in #{mode} mode: #{inspect(result)}"
+    end
+
+    [{_, sync} | rest] = results
+
+    for {mode, result} <- rest do
+      assert result == sync, "#{mode} mode result differs from SYNC: #{inspect(result)}"
+    end
+
+    sync
+  end
+
+  test "fully resolved values are identical across modes" do
+    result =
+      assert_all_modes_agree(
+        """
+        query ($mode: Mode!) { okThings(mode: $mode) { name nullableName } }
+        """,
+        %{
+          "okThings" => [
+            %{"name" => "thing-1", "nullableName" => "thing-1"},
+            %{"name" => "thing-2", "nullableName" => "thing-2"}
+          ]
+        }
+      )
+
+    refute Map.has_key?(result, :errors)
+  end
+
+  test "nil in a non-null field nullifies the parent object across modes" do
+    result =
+      assert_all_modes_agree(
+        """
+        query ($mode: Mode!) { thing(mode: $mode) { name } }
+        """,
+        %{"thing" => nil}
+      )
+
+    assert [%{message: "Cannot return null for non-nullable field", path: ["thing", "name"]}] =
+             result.errors
+  end
+
+  test "nil non-null leaf under a nullable leaf sibling across modes" do
+    result =
+      assert_all_modes_agree(
+        """
+        query ($mode: Mode!) { thing(mode: $mode) { name nullableName } }
+        """,
+        %{"thing" => nil}
+      )
+
+    assert [%{path: ["thing", "name"]}] = result.errors
+  end
+
+  test "non-null propagation crosses multiple object levels across modes" do
+    result =
+      assert_all_modes_agree(
+        """
+        query ($mode: Mode!) { deep(mode: $mode) { thing { name } } }
+        """,
+        %{"deep" => nil}
+      )
+
+    assert [%{path: ["deep", "thing", "name"]}] = result.errors
+  end
+
+  test "nil non-null element nullifies a list of non-null objects across modes" do
+    result =
+      assert_all_modes_agree(
+        """
+        query ($mode: Mode!) { things(mode: $mode) { name } }
+        """,
+        %{"things" => nil}
+      )
+
+    assert [%{path: ["things", 1, "name"]}] = result.errors
+  end
+
+  test "nullable scalar lists are identical across modes" do
+    result =
+      assert_all_modes_agree(
+        """
+        query ($mode: Mode!) { okThings(mode: $mode) { nullableName tags } }
+        """,
+        %{
+          "okThings" => [
+            %{"nullableName" => "thing-1", "tags" => ["a-1", nil, "b-1"]},
+            %{"nullableName" => "thing-2", "tags" => ["a-2", nil, "b-2"]}
+          ]
+        }
+      )
+
+    refute Map.has_key?(result, :errors)
+  end
+
+  test "nil element in a list of non-null scalars nullifies the list across modes" do
+    result =
+      assert_all_modes_agree(
+        """
+        query ($mode: Mode!) { okThings(mode: $mode) { nullableName strictTags } }
+        """,
+        %{
+          "okThings" => [
+            %{"nullableName" => "thing-1", "strictTags" => nil},
+            %{"nullableName" => "thing-2", "strictTags" => nil}
+          ]
+        }
+      )
+
+    assert [
+             %{path: ["okThings", 0, "strictTags", 1]},
+             %{path: ["okThings", 1, "strictTags", 1]}
+           ] = Enum.sort_by(result.errors, & &1.path)
+  end
+
+  test "propagation through chained suspensions across modes" do
+    result =
+      assert_all_modes_agree(
+        """
+        query ($mode: Mode!) { chain(mode: $mode) { child { name } } }
+        """,
+        %{"chain" => nil}
+      )
+
+    assert [%{path: ["chain", "child", "name"]}] = result.errors
+  end
+end


### PR DESCRIPTION
# Rework resolution to stop re-walking the result tree

## The problem

The resolution phase re-runs once per "round" of suspension (async, batch,
dataloader). Each re-run walked the *entire* result tree (including subtrees
that fully resolved in an earlier pass) just to find the suspended fields.
For a document with S result nodes and K suspension rounds (chained dataloader
batches being the common worst case), that's O(K × S) work and allocation,
even though the useful work per round is only the suspended fields themselves.

## What changed

**Suspended fields now live in a flat pool instead of the tree.** When a field
suspends, it leaves a lightweight `%Result.Pending{ref: ref}` placeholder in
the result tree and the suspended `%Absinthe.Resolution{}` goes into
`execution.pending`. Re-runs of the resolution phase iterate only that pool —
the tree is never re-walked. Once nothing remains suspended, a single
substitution pass splices the resolved subtrees in over their placeholders,
applying non-null propagation along the changed paths.

**This fixes #1094.** Previously, a batched/async/dataloader field that
resolved to `nil` in a `non_null` position produced the error but did *not*
nullify its ancestors, returning spec-invalid data (the old re-walk rebuilt
ancestor objects without re-applying null trimming). Null propagation is now
identical whether a field resolves synchronously or suspends — covered by a
new test suite that runs the same documents in sync/batch/async modes and
requires identical results. This is a behavior change for anyone depending on
the old, non-compliant shape.

**Plus a round of sync-pass optimizations**: fields using the default
`MapGet` resolver skip building a resolution struct entirely (a pure
`Map.get/2` cannot error or suspend, so the struct and middleware loop were
pure overhead), list elements share one prepared emitter instead of
re-expanding the field's type per element (borrowed from #1448 — purely
internal, result nodes carry identical values), the concrete parent type is
recorded once in the cached projection instead of copied onto every field per
element, and lists skip the null-trimming rebuild when nothing needs
trimming.

Deliberately **not** included: the rest of #1448 — in particular
`Result.LeafList`, which changes the result node set that custom result
phases walk and so needs a coordinated absinthe_phoenix release; it should
ship as its own PR.

## Numbers

Resolution + result phases, 10k-item list with 4 scalar fields each
(`benchmarks/resolution_rewalk.exs`; chain_24 = 24 chained batch levels next
to the wide tree, i.e. 25 resolution passes):

| Scenario | before | after |
|---|---|---|
| sync (1 pass) | 33.2 ms / 65.9 MB | **19.3 ms / 26.3 MB** |
| batched N+1 (2 passes) | 60.8 ms / 126 MB | **45.9 ms / 83.7 MB** |
| chain_24 (25 passes) | 81.9 ms / 418 MB | **15.0 ms / 31.3 MB** |

The suspension-round penalty is effectively gone: each additional round now
costs O(pending fields) instead of O(tree), so chain_24 runs ~5x faster with
~13x less allocation. The all-sync pass is ~40% faster with ~60% less
allocation, and the dense single-round N+1 case is ~25% faster with ~35%
less allocation.

## Compatibility notes

- `Absinthe.run/3` output is unchanged except for the #1094 fix above.
- A new internal result node exists (`Result.Pending`) and
  `%Blueprint.Execution{}` grew `pending`/`resolved` fields. `Pending` never
  survives to the result phase in normal operation, so custom result phases
  are unaffected.
- Fields resolved by the default `MapGet` middleware no longer construct an
  `%Absinthe.Resolution{}` at any point. Nothing can observe the difference
  (no middleware runs for such fields, and abstract-typed fields keep the
  regular path), but the invariant is worth knowing.
- Within a re-run, suspended fields resume in document order from the pool;
  interleaving with newly-suspended nested fields can differ slightly from
  the old tree-order walk. Batch/async/dataloader are order-insensitive.