### PR TITLE
feat: LeafList optimization for nullable lists of scalars

### DIFF
--- a/benchmarks/memory_footprint.exs
+++ b/benchmarks/memory_footprint.exs
@@ -1,0 +1,38 @@
+# Total allocation (churn) per query, via Benchee's memory measurement.
+#
+#     mix run benchmarks/memory_footprint.exs
+#
+# See benchmarks/support/mem_bench.exs for the shared schema/scenarios and for
+# how churn relates to the peak measured by memory_peak.exs.
+
+Code.require_file("support/mem_bench.exs", __DIR__)
+
+MemBench.seed_data()
+
+tail = MemBench.resolution_tail()
+bp_things = MemBench.prepare("{ things { a b } }")
+bp_strings = MemBench.prepare("{ strings }")
+bp_strings_nn = MemBench.prepare("{ stringsNonNull }")
+
+MemBench.sanity_check!(bp_things, bp_strings, bp_strings_nn, tail)
+
+# Benchee's comparison section relates every job in a run, which only makes
+# sense for jobs over the same workload: the two strings scenarios resolve
+# identical data (nullable vs non-null element type). The objects scenario is
+# a different workload, reported separately as absolute numbers.
+Benchee.run(
+  %{
+    "100k strings [String]" => fn -> MemBench.resolve(bp_strings, tail) end,
+    "100k strings [String!]" => fn -> MemBench.resolve(bp_strings_nn, tail) end
+  },
+  warmup: 1,
+  time: 2,
+  memory_time: 2
+)
+
+Benchee.run(
+  %{"20k objects / 40k leaves" => fn -> MemBench.resolve(bp_things, tail) end},
+  warmup: 1,
+  time: 2,
+  memory_time: 2
+)

--- a/benchmarks/memory_peak.exs
+++ b/benchmarks/memory_peak.exs
@@ -1,0 +1,129 @@
+# Peak process memory during resolution of large result sets.
+#
+#     mix run benchmarks/memory_peak.exs
+#
+# Each scenario runs in a fresh process; a sampler polls
+# `:erlang.process_info(pid, :memory)` in a tight loop and records the peak.
+# See benchmarks/support/mem_bench.exs for the shared schema/scenarios and for
+# how the peak relates to the allocation churn measured by
+# memory_footprint.exs.
+#
+# "payload" is `byte_size(:erlang.term_to_binary(result))`, a rough proxy for
+# the JSON response size; "ratio" is peak/payload — how much memory it takes
+# to produce one byte of response.
+
+Code.require_file("support/mem_bench.exs", __DIR__)
+
+defmodule MemBench.Peak do
+  # Runs `fun` in a fresh process and returns its peak memory and result size.
+  def measure(fun) do
+    parent = self()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        receive do
+          :go -> :ok
+        end
+
+        result = fun.()
+        # term_to_binary runs a bit larger than JSON, so payload ratios are
+        # conservative. It also keeps the result alive so the peak includes
+        # it, without skewing the measurement: the binary is refc (off-heap),
+        # whereas e.g. :erts_debug.size/1 would build a sharing-tracking set
+        # on this process's heap and inflate the peak ~10x for large lists.
+        send(parent, {:result_size, byte_size(:erlang.term_to_binary(result))})
+      end)
+
+    sampler =
+      spawn(fn ->
+        send(parent, {:peak, sample_loop(pid, 0)})
+      end)
+
+    send(pid, :go)
+
+    peak =
+      receive do
+        {:peak, peak} -> peak
+      end
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, :normal} -> :ok
+      {:DOWN, ^ref, :process, ^pid, reason} -> raise "measured process died: #{inspect(reason)}"
+    end
+
+    # The worker sends :result_size before it exits, so once the DOWN message
+    # has been seen it is guaranteed to be in the mailbox.
+    result_bytes =
+      receive do
+        {:result_size, bytes} -> bytes
+      after
+        0 -> raise "missing result size message"
+      end
+
+    _ = sampler
+    %{peak: peak, result_bytes: result_bytes}
+  end
+
+  defp sample_loop(pid, max) do
+    case :erlang.process_info(pid, :memory) do
+      {:memory, bytes} -> sample_loop(pid, max(bytes, max))
+      :undefined -> max
+    end
+  end
+
+  def run_scenario(name, fun, rounds) do
+    results = for _ <- 1..rounds, do: measure(fun)
+    peaks = Enum.map(results, & &1.peak)
+    # The result is deterministic, so its size is the same in every round.
+    payload = hd(results).result_bytes
+    peak = median(peaks)
+    ratio = if payload > 0, do: peak / payload, else: 0.0
+
+    :io.format(
+      "~-28s peak: ~7.2f MB   payload: ~5.2f MB   ratio: ~5.1fx   (min ~.2f, max ~.2f over ~b rounds)~n",
+      [
+        name,
+        peak / 1_048_576,
+        payload / 1_048_576,
+        ratio,
+        Enum.min(peaks) / 1_048_576,
+        Enum.max(peaks) / 1_048_576,
+        rounds
+      ]
+    )
+  end
+
+  defp median(list) do
+    sorted = Enum.sort(list)
+    Enum.at(sorted, div(length(sorted), 2))
+  end
+end
+
+MemBench.seed_data()
+
+tail = MemBench.resolution_tail()
+bp_things = MemBench.prepare("{ things { a b } }")
+bp_strings = MemBench.prepare("{ strings }")
+bp_strings_nn = MemBench.prepare("{ stringsNonNull }")
+
+MemBench.sanity_check!(bp_things, bp_strings, bp_strings_nn, tail)
+
+rounds = 7
+
+MemBench.Peak.run_scenario(
+  "20k objects / 40k leaves",
+  fn -> MemBench.resolve(bp_things, tail) end,
+  rounds
+)
+
+MemBench.Peak.run_scenario(
+  "100k strings [String]",
+  fn -> MemBench.resolve(bp_strings, tail) end,
+  rounds
+)
+
+MemBench.Peak.run_scenario(
+  "100k strings [String!]",
+  fn -> MemBench.resolve(bp_strings_nn, tail) end,
+  rounds
+)

--- a/benchmarks/support/mem_bench.exs
+++ b/benchmarks/support/mem_bench.exs
@@ -1,0 +1,123 @@
+# Shared schema, data, and pipeline helpers for the memory benchmarks
+# (memory_footprint.exs and memory_peak.exs), written for issue #1245 (large
+# list results using far more RAM than the response size).
+#
+# The two runner scripts measure different things, and both matter:
+#
+#   * memory_footprint.exs — total bytes ALLOCATED per run (churn), via
+#     Benchee. Churn drives how often GC runs, i.e. CPU cost and latency.
+#   * memory_peak.exs — the high-water mark of memory reserved for the
+#     process. The peak is what `:max_heap_size` kills and OOM care about.
+#
+# Churn is usually the larger number, but a (nearly) zero-garbage run can push
+# it below the peak: allocation approaches the size of the retained result,
+# while the peak still includes BEAM heap-block overhead — blocks grow on a
+# fixed stage schedule, and a copying GC where everything survives briefly
+# needs from-space and to-space at once. E.g. 100k nullable strings allocate
+# ~1.53 MB (exactly the result list's cons cells; the strings themselves are
+# literal-area references) while peaking at ~2.45 MB of heap capacity.
+#
+# Source data is generated once and stashed in :persistent_term (reads are not
+# copied) and the telemetry phase is excluded from the measured pipeline, so
+# measurements cover resolution + result construction only.
+#
+# Scenarios:
+#
+#   * 20k objects / 40k leaves — `{ things { a b } }` over 20,000 objects,
+#     each with two string fields.
+#   * 100k strings [String] — `list_of(:string)` with 100,000 elements
+#     (compact LeafList representation).
+#   * 100k strings [String!] — same data as `list_of(non_null(:string))`,
+#     which keeps the per-element Result.Leaf representation.
+
+defmodule MemBench.Schema do
+  use Absinthe.Schema
+
+  object :thing do
+    field :a, :string
+    field :b, :string
+  end
+
+  query do
+    field :things, list_of(:thing) do
+      resolve fn _, _, _ -> {:ok, :persistent_term.get({MemBench, :things})} end
+    end
+
+    field :strings, list_of(:string) do
+      resolve fn _, _, _ -> {:ok, :persistent_term.get({MemBench, :strings})} end
+    end
+
+    field :strings_non_null, list_of(non_null(:string)) do
+      resolve fn _, _, _ -> {:ok, :persistent_term.get({MemBench, :strings})} end
+    end
+  end
+end
+
+defmodule MemBench do
+  alias Absinthe.{Pipeline, Phase}
+
+  @resolution_phase Phase.Document.Execution.Resolution
+
+  @things_count 20_000
+  @strings_count 100_000
+
+  def seed_data() do
+    things = for i <- 1..@things_count, do: %{a: "aaaa-#{i}", b: "bbbb-#{i}"}
+    strings = for i <- 1..@strings_count, do: "string-#{i}"
+
+    :persistent_term.put({MemBench, :things}, things)
+    :persistent_term.put({MemBench, :strings}, strings)
+  end
+
+  def prepare(query) do
+    pipeline = Pipeline.for_document(MemBench.Schema, [])
+    {:ok, bp, _} = Pipeline.run(query, Pipeline.before(pipeline, @resolution_phase))
+    bp
+  end
+
+  def resolution_tail() do
+    MemBench.Schema
+    |> Pipeline.for_document([])
+    |> Pipeline.from(@resolution_phase)
+    |> Pipeline.without(Phase.Telemetry)
+  end
+
+  def resolve(bp, tail) do
+    {:ok, bp, _} = Pipeline.run(bp, tail)
+    bp.result
+  end
+
+  def sanity_check!(bp_things, bp_strings, bp_strings_nn, tail) do
+    %{data: %{"things" => things}} = result = resolve(bp_things, tail)
+
+    unless length(things) == @things_count and not Map.has_key?(result, :errors) do
+      raise "sanity check failed for things: #{inspect(Map.delete(result, :data))}"
+    end
+
+    unless %{"a" => "aaaa-1", "b" => "bbbb-1"} == hd(things) do
+      raise "sanity check failed for things content: #{inspect(hd(things))}"
+    end
+
+    %{data: %{"strings" => strings}} = result = resolve(bp_strings, tail)
+
+    unless length(strings) == @strings_count and not Map.has_key?(result, :errors) do
+      raise "sanity check failed for strings: #{inspect(Map.delete(result, :data))}"
+    end
+
+    unless hd(strings) == "string-1" do
+      raise "sanity check failed for strings content: #{inspect(hd(strings))}"
+    end
+
+    %{data: %{"stringsNonNull" => strings_nn}} = result = resolve(bp_strings_nn, tail)
+
+    unless length(strings_nn) == @strings_count and not Map.has_key?(result, :errors) do
+      raise "sanity check failed for stringsNonNull: #{inspect(Map.delete(result, :data))}"
+    end
+
+    unless hd(strings_nn) == "string-1" do
+      raise "sanity check failed for stringsNonNull content: #{inspect(hd(strings_nn))}"
+    end
+
+    IO.puts("sanity checks passed\n")
+  end
+end

--- a/lib/absinthe/blueprint/execution.ex
+++ b/lib/absinthe/blueprint/execution.ex
@@ -57,6 +57,7 @@ defmodule Absinthe.Blueprint.Execution do
   @type node_t ::
           Result.Object
           | Result.List
+          | Result.LeafList
           | Result.Leaf
           | Result.Pending
 

--- a/lib/absinthe/blueprint/result/leaf_list.ex
+++ b/lib/absinthe/blueprint/result/leaf_list.ex
@@ -1,0 +1,29 @@
+defmodule Absinthe.Blueprint.Result.LeafList do
+  @moduledoc false
+
+  # A list result whose elements are leaf values (scalars or enums) with a
+  # nullable element type. Such elements never run middleware and cannot be
+  # errored or null-trimmed individually, so the list is held as one node of
+  # raw values instead of a `Result.Leaf` per element, and is serialized in
+  # bulk by `Absinthe.Phase.Document.Result`. Lists with a non-null element
+  # type keep the per-element representation to preserve null propagation.
+
+  alias Absinthe.{Blueprint, Phase}
+
+  @enforce_keys [:emitter]
+  defstruct [
+    :emitter,
+    values: [],
+    errors: [],
+    flags: %{},
+    extensions: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          emitter: Blueprint.Document.Field.t(),
+          values: [term()],
+          errors: [Phase.Error.t()],
+          flags: Blueprint.flags_t(),
+          extensions: %{any => any}
+        }
+end

--- a/lib/absinthe/phase/document/execution/resolution.ex
+++ b/lib/absinthe/phase/document/execution/resolution.ex
@@ -189,7 +189,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   # longer needs it — downstream result phases can consume it (e.g.
   # Absinthe.Phoenix.Controller.Result returns raw source values for objects
   # without subselections and merges them for `@put`).
-  def walk_result(%{fields: nil} = result, bp_node, _schema_type, res, path) do
+  def walk_result(%Result.Object{fields: nil} = result, bp_node, _schema_type, res, path) do
     {fields, res} = resolve_fields(bp_node, res, result.root_value, path)
     {%{result | fields: fields}, res}
   end
@@ -198,19 +198,24 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     {result, res}
   end
 
-  def walk_result(%{values: values} = result, bp_node, schema_type, res, path) do
+  # Compact scalar/enum list: its raw values have no fields to resolve.
+  def walk_result(%Result.LeafList{} = result, _, _, res, _) do
+    {result, res}
+  end
+
+  def walk_result(%Result.List{values: values} = result, bp_node, schema_type, res, path) do
     {values, res} = walk_results(values, bp_node, schema_type, res, [0 | path], [])
     {%{result | values: values}, res}
   end
 
-  # walk list results
+  # Walk list results. The element path is threaded as an argument rather than
+  # written to `res` (which would copy the struct once per element). Only Union
+  # and Interface `resolve_type` callbacks read the path off `res`;
+  # `get_concrete_type` sets it there right before invoking them.
   defp walk_results([value | values], bp_node, inner_type, res, [i | sub_path] = path, acc) do
-    {result, res} = walk_result(value, bp_node, inner_type, %{res | path: path}, path)
+    {result, res} = walk_result(value, bp_node, inner_type, res, path)
     walk_results(values, bp_node, inner_type, res, [i + 1 | sub_path], [result | acc])
   end
-
-  defp walk_results([], _, _, res = %{path: [_ | sub_path]}, _, acc),
-    do: {:lists.reverse(acc), %{res | path: sub_path}}
 
   defp walk_results([], _, _, res, _, acc), do: {:lists.reverse(acc), res}
 
@@ -219,7 +224,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     # that return type could be an interface or union, so let's make it concrete
     parent
     |> get_return_type
-    |> get_concrete_type(source, res)
+    |> get_concrete_type(source, res, path)
     |> case do
       nil ->
         {[], res}
@@ -251,15 +256,15 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   defp get_return_type(type), do: type
 
-  defp get_concrete_type(%Type.Union{} = parent_type, source, res) do
-    Type.Union.resolve_type(parent_type, source, res)
+  defp get_concrete_type(%Type.Union{} = parent_type, source, res, path) do
+    Type.Union.resolve_type(parent_type, source, %{res | path: path})
   end
 
-  defp get_concrete_type(%Type.Interface{} = parent_type, source, res) do
-    Type.Interface.resolve_type(parent_type, source, res)
+  defp get_concrete_type(%Type.Interface{} = parent_type, source, res, path) do
+    Type.Interface.resolve_type(parent_type, source, %{res | path: path})
   end
 
-  defp get_concrete_type(parent_type, _source, _res) do
+  defp get_concrete_type(parent_type, _source, _res, _path) do
     parent_type
   end
 
@@ -462,18 +467,34 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
   end
 
   defp maybe_add_non_null_error([], [_ | _] = values, %Type.List{of_type: type}, path) do
-    values
-    |> Enum.with_index()
-    |> Enum.flat_map(fn {value, index} ->
-      maybe_add_non_null_error([], value, type, [index | path])
-    end)
+    # Only a non-null element type can produce a violation, so plain `[Foo]`
+    # lists skip the walk entirely. The element index is carried through the
+    # recursion for the error path.
+    if contains_non_null?(type) do
+      list_non_null_errors(values, type, path, 0)
+    else
+      []
+    end
   end
 
   defp maybe_add_non_null_error(errors, _, _, _path) do
     errors
   end
 
-  defp propagate_null_trimming({%{values: values} = node, res}) do
+  defp list_non_null_errors([], _type, _path, _index), do: []
+
+  defp list_non_null_errors([value | values], type, path, index) do
+    case maybe_add_non_null_error([], value, type, [index | path]) do
+      [] -> list_non_null_errors(values, type, path, index + 1)
+      errors -> errors ++ list_non_null_errors(values, type, path, index + 1)
+    end
+  end
+
+  defp contains_non_null?(%Type.NonNull{}), do: true
+  defp contains_non_null?(%Type.List{of_type: inner}), do: contains_non_null?(inner)
+  defp contains_non_null?(_), do: false
+
+  defp propagate_null_trimming({%Result.List{values: values} = node, res}) do
     # Only rebuild the list when something actually needs to be trimmed; in the
     # common all-good case this avoids re-allocating the values list (and a
     # copy of the node) just to put back identical elements.
@@ -513,11 +534,11 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     find_bad_child(element) || non_null_list_violation?(element)
   end
 
-  defp find_bad_child(%{fields: fields}) do
+  defp find_bad_child(%Result.Object{fields: fields}) do
     Enum.find(fields, &non_null_violation?/1)
   end
 
-  defp find_bad_child(%{values: values}) do
+  defp find_bad_child(%Result.List{values: values}) do
     Enum.find(values, &non_null_list_violation?/1)
   end
 
@@ -534,7 +555,7 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
     false
   end
 
-  defp non_null_list_violation?(%{values: values}) do
+  defp non_null_list_violation?(%Result.List{values: values}) do
     Enum.find(values, &non_null_list_violation?/1)
   end
 
@@ -615,6 +636,14 @@ defmodule Absinthe.Phase.Document.Execution.Resolution do
 
   defp to_result(root_value, blueprint, %Type.Union{}, extensions) do
     %Result.Object{root_value: root_value, emitter: blueprint, extensions: extensions}
+  end
+
+  # A list of nullable leaf values is kept as one compact node — see
+  # Result.LeafList. Non-null element types don't match this clause and fall
+  # through to the per-element form below, preserving null propagation.
+  defp to_result(root_value, blueprint, %Type.List{of_type: %leaf{}}, extensions)
+       when leaf in [Type.Scalar, Type.Enum] do
+    %Result.LeafList{values: List.wrap(root_value), emitter: blueprint, extensions: extensions}
   end
 
   defp to_result(root_value, blueprint, %Type.List{of_type: inner_type}, extensions) do

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -56,40 +56,50 @@ defmodule Absinthe.Phase.Document.Result do
 
   defp data(%{errors: [_ | _] = field_errors}, errors), do: {nil, field_errors ++ errors}
 
+  # Serialize a LeafList's raw values in one pass — see Result.LeafList.
+  defp data(%Blueprint.Result.LeafList{values: values, emitter: emitter}, errors) do
+    schema_node = Type.unwrap(emitter.schema_node.type)
+
+    serialized =
+      Enum.map(values, fn
+        nil -> nil
+        value -> serialize_leaf(schema_node, value, emitter)
+      end)
+
+    {serialized, errors}
+  end
+
   # Leaf
   defp data(%{value: nil}, errors), do: {nil, errors}
 
   defp data(%{value: value, emitter: emitter}, errors) do
-    value =
-      case Type.unwrap(emitter.schema_node.type) do
-        %Type.Scalar{} = schema_node ->
-          try do
-            Type.Scalar.serialize(schema_node, value)
-          rescue
-            _e in [Absinthe.SerializationError, Protocol.UndefinedError] ->
-              raise(
-                Absinthe.SerializationError,
-                """
-                Could not serialize term #{inspect(value)} as type #{schema_node.name}
-
-                When serializing the field:
-                #{emitter.parent_type.name}.#{emitter.schema_node.name} (#{emitter.schema_node.__reference__.location.file}:#{emitter.schema_node.__reference__.location.line})
-                """
-              )
-          end
-
-        %Type.Enum{} = schema_node ->
-          Type.Enum.serialize(schema_node, value)
-      end
-
-    {value, errors}
+    {serialize_leaf(Type.unwrap(emitter.schema_node.type), value, emitter), errors}
   end
 
   # Object
   defp data(%{fields: fields}, errors), do: field_data(fields, errors)
 
   # List
-  defp data(%{values: values}, errors), do: list_data(values, errors)
+  defp data(%Blueprint.Result.List{values: values}, errors), do: list_data(values, errors)
+
+  defp serialize_leaf(%Type.Scalar{} = schema_node, value, emitter) do
+    Type.Scalar.serialize(schema_node, value)
+  rescue
+    _e in [Absinthe.SerializationError, Protocol.UndefinedError] ->
+      raise(
+        Absinthe.SerializationError,
+        """
+        Could not serialize term #{inspect(value)} as type #{schema_node.name}
+
+        When serializing the field:
+        #{emitter.parent_type.name}.#{emitter.schema_node.name} (#{emitter.schema_node.__reference__.location.file}:#{emitter.schema_node.__reference__.location.line})
+        """
+      )
+  end
+
+  defp serialize_leaf(%Type.Enum{} = schema_node, value, _emitter) do
+    Type.Enum.serialize(schema_node, value)
+  end
 
   defp list_data(fields, errors, acc \\ [])
   defp list_data([], errors, acc), do: {:lists.reverse(acc), errors}

--- a/test/absinthe/execution/list_test.exs
+++ b/test/absinthe/execution/list_test.exs
@@ -18,6 +18,16 @@ defmodule Absinthe.Execution.ListTest.Schema do
       end
     end
 
+    field :categories_with_nils, list_of(:string) do
+      resolve fn _, _ ->
+        {:ok, ["foo", nil, "baz", nil]}
+      end
+    end
+
+    field :list_of_list_of_numbers_with_nils, list_of(list_of(:integer)) do
+      resolve fn _, _ -> {:ok, [[1, nil, 3], nil, [4]]} end
+    end
+
     field :items, list_of(:item) do
       resolve fn _, _ ->
         items = [
@@ -110,6 +120,28 @@ defmodule Absinthe.Execution.ListTest do
 
   test "should resolve list of numbers" do
     assert {:ok, %{data: %{"numbers" => [1, 2, 3]}}} == Absinthe.run(@query, __MODULE__.Schema)
+  end
+
+  @query """
+  {
+    categoriesWithNils
+  }
+  """
+
+  test "should keep nil elements in a list of nullable strings" do
+    assert {:ok, %{data: %{"categoriesWithNils" => ["foo", nil, "baz", nil]}}} ==
+             Absinthe.run(@query, __MODULE__.Schema)
+  end
+
+  @query """
+  {
+    listOfListOfNumbersWithNils
+  }
+  """
+
+  test "should keep nil elements and nil inner lists in nested nullable lists" do
+    assert {:ok, %{data: %{"listOfListOfNumbersWithNils" => [[1, nil, 3], nil, [4]]}}} ==
+             Absinthe.run(@query, __MODULE__.Schema)
   end
 
   @query """

--- a/test/absinthe/integration/execution/serialization_test.exs
+++ b/test/absinthe/integration/execution/serialization_test.exs
@@ -20,6 +20,10 @@ defmodule Absinthe.Integration.Execution.SerializationTest do
       field :bad_string, :string do
         resolve fn _, _, _ -> {:ok, %{}} end
       end
+
+      field :bad_string_list, list_of(:string) do
+        resolve fn _, _, _ -> {:ok, ["ok", %{}]} end
+      end
     end
   end
 
@@ -54,6 +58,15 @@ defmodule Absinthe.Integration.Execution.SerializationTest do
   query { badString }
   """
   test "returning a type that can't `to_string` for a string raises" do
+    assert_raise(Absinthe.SerializationError, fn ->
+      Absinthe.run(@query, Schema)
+    end)
+  end
+
+  @query """
+  query { badStringList }
+  """
+  test "returning a type that can't `to_string` inside a list of strings raises" do
     assert_raise(Absinthe.SerializationError, fn ->
       Absinthe.run(@query, Schema)
     end)


### PR DESCRIPTION
Extract the LeafList part from #1448. The rest of the PR was folded into #1450.

The new result node (Absinthe.Blueprint.Result.LeafList) introduced here is used by absinthe_phoenix, so using the next version of absinthe will require updating absinthe_phoenix to include this PR: https://github.com/absinthe-graphql/absinthe_phoenix/pull/111