### PR TITLE
fix: raise when projecting from an abstract type

### DIFF
--- a/lib/absinthe/resolution.ex
+++ b/lib/absinthe/resolution.ex
@@ -92,7 +92,7 @@ defmodule Absinthe.Resolution do
   See `project/2` for details.
   """
   def project(info) do
-    case info.definition.schema_node.type do
+    case Absinthe.Schema.lookup_type(info.schema, info.definition.schema_node.type) do
       %Absinthe.Type.Interface{} ->
         raise need_concrete_type_error()
 

--- a/test/absinthe/resolution_test.exs
+++ b/test/absinthe/resolution_test.exs
@@ -44,6 +44,36 @@ defmodule Absinthe.ResolutionTest do
           {:error, ~D[2025-01-01]}
         end
       end
+
+      field :abstract_resolver, :named do
+        resolve fn _, info ->
+          Absinthe.Resolution.project(info)
+          {:ok, nil}
+        end
+      end
+
+      field :non_null_abstract_resolver, non_null(:named) do
+        resolve fn _, info ->
+          Absinthe.Resolution.project(info)
+          {:ok, nil}
+        end
+      end
+
+      field :list_abstract_resolver, list_of(:named) do
+        resolve fn _, info ->
+          Absinthe.Resolution.project(info)
+          {:ok, nil}
+        end
+      end
+
+      field :abstract_resolver_with_type, :named do
+        resolve fn _, info ->
+          fields = Absinthe.Resolution.project(info, :user) |> Enum.map(& &1.name)
+
+          send(self(), {:fields, fields})
+          {:ok, nil}
+        end
+      end
     end
   end
 
@@ -78,6 +108,48 @@ defmodule Absinthe.ResolutionTest do
     assert_receive({:fields, fields})
 
     assert ["id", "name"] == fields
+  end
+
+  test "project/1 raises on an abstract type" do
+    doc = """
+    { abstractResolver { name ... on User { id } } }
+    """
+
+    assert_raise RuntimeError, ~r/Use `project\/2` instead of `project\/1`/, fn ->
+      Absinthe.run(doc, Schema)
+    end
+  end
+
+  test "project/1 raises on a non null abstract type" do
+    doc = """
+    { nonNullAbstractResolver { name ... on User { id } } }
+    """
+
+    assert_raise RuntimeError, ~r/Use `project\/2` instead of `project\/1`/, fn ->
+      Absinthe.run(doc, Schema)
+    end
+  end
+
+  test "project/1 raises on a list of an abstract type" do
+    doc = """
+    { listAbstractResolver { name ... on User { id } } }
+    """
+
+    assert_raise RuntimeError, ~r/Use `project\/2` instead of `project\/1`/, fn ->
+      Absinthe.run(doc, Schema)
+    end
+  end
+
+  test "project/2 works on an abstract type" do
+    doc = """
+    { abstractResolverWithType { name ... on User { id } } }
+    """
+
+    {:ok, _} = Absinthe.run(doc, Schema)
+
+    assert_receive({:fields, fields})
+
+    assert ["name", "id"] == fields
   end
 
   test "invalid resolver" do


### PR DESCRIPTION
`Absinthe.Resolution.project/1` is meant to raise when you call it on a field
returning an interface or a union, pointing you at `project/2` with a concrete
type. That error never fires.

The check pattern matches on `%Type.Interface{}` / `%Type.Union{}`, but
`schema_node.type` holds the type identifier at that point (or a `NonNull` /
`List` wrapper around it), so it always falls through to the last clause.
Projection then runs with an abstract parent type and `passes_type_condition?/2`
drops every `... on ConcreteType` fragment via its catch-all. You get a partial
field list back and nothing tells you something went missing.

I noticed this while reading the projector code. It matters for anything that
builds preload trees from `project/1` — on polymorphic fields you get a partial
tree with no signal that anything was dropped.

The fix is to look the type up before matching on it. Tests cover interface,
`non_null` and `list_of` return types, plus one making sure `project/2` with a
concrete type still works.

One thing worth flagging: this is a behaviour change. Code calling `project/1`
on abstract fields now gets an exception where it used to get a truncated list.
It's the documented contract — that error message has been there since #317 —
but it will surface for anyone relying on what it does today.

#761 tried to make projection actually work on abstract types; this is
deliberately much smaller, just making the existing guard do what it says.
